### PR TITLE
Add search guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 target
 build
 *.xliff
+.DS_Store

--- a/content/guides/search/index.md
+++ b/content/guides/search/index.md
@@ -1,0 +1,9 @@
+---
+rank: 1
+related_endpoints: []
+related_guides: []
+required_guides: []
+alias_paths: []
+---
+
+# Search

--- a/content/guides/search/search-content.md
+++ b/content/guides/search/search-content.md
@@ -1,0 +1,25 @@
+---
+rank: 2
+related_endpoints:
+ - get_search
+related_guides:
+ - metadata
+ - users
+required_guides: []
+alias_paths: []
+---
+
+# Search for content
+
+This guide will take you through the methods of searching through content
+within a Box account.
+
+## Searching by terms
+
+To find files and folders within a Box account by using a given search query,
+use the query search method within the SDK, passing in keywords and filters as needed.
+
+Define your search terms and filters by using the available fields. Next, call
+the search endpoint with the defined criteria to return the give files and
+folders that are matched.
+<Samples id='get_search' />


### PR DESCRIPTION
Related guides are probably mangled since we don't yet have those. I can update them to specific planned guides if needed.

I _think_ I got the right sample for the build.