### PR TITLE
Upddate Postman url

### DIFF
--- a/content/guides/tooling/postman/index.md
+++ b/content/guides/tooling/postman/index.md
@@ -39,6 +39,6 @@ to get many more updates including some to make authentication a lot easier.
   Postman Chrome application. 
 </Mesage>
 
-[postman]: https://getpostman.com
-[legacy]: https://www.getpostman.com/collections/768279fde466dffc5511
+[postman]: https://postman.com
+[legacy]: https://www.postman.com/collections/768279fde466dffc5511
 [openapi]: https://github.com/box/box-openapi


### PR DESCRIPTION
The Postman url changed from www.getpostman.com to www.postman.com 🎸