### PR TITLE
Add minimum required scopes to postman quickstart

### DIFF
--- a/content/guides/tooling/postman/quick-start/2-configure-box-app.md
+++ b/content/guides/tooling/postman/quick-start/2-configure-box-app.md
@@ -69,7 +69,7 @@ extra steps to set up.
   1. Scroll to the **Application Scopes** section of the same screen
      and select any additional permissions you want to enable for this application.
      **Your application must have at least one or more of the following scopes:** 
-     manage users,read all files and folders stored in Box, read and write all files 
+     manage users, read all files and folders stored in Box, read and write all files 
      and folders in Box.
   1. At the top of the page click the button to **Save Changes**
 </Choice>

--- a/content/guides/tooling/postman/quick-start/2-configure-box-app.md
+++ b/content/guides/tooling/postman/quick-start/2-configure-box-app.md
@@ -66,11 +66,10 @@ extra steps to set up.
   1. Go to the app's configuration by clicking **View Your App**.
   1. Scroll down to the **OAuth 2.0 redirect URI** configuration and set the
      **Redirect URI** to the value `https://developer.box.com/auth/callback`.
-  1. Scroll to the **Application Scopes** section of the same screen
-     and select any additional permissions you want to enable for this application.
-     **Your application must have at least one or more of the following scopes:** 
-     manage users, read all files and folders stored in Box, read and write all files 
-     and folders in Box.
+  1. Scroll down to the **Application Scopes** section to select your desired
+     [permissions][scopes]. **Your application must have at least one or more**
+     **of the following scopes:** manage users, read all files and folders
+     stored in Box, read and write all files and folders in Box.
   1. At the top of the page click the button to **Save Changes**
 </Choice>
 
@@ -124,3 +123,4 @@ extra steps to set up.
 
 [devconsole]: https://account.box.com/developers/services
 [signup]: https://account.box.com/signup/n/developer
+[scopes]: https://developer.box.com/guides/api-calls/permissions-and-errors/scopes/

--- a/content/guides/tooling/postman/quick-start/2-configure-box-app.md
+++ b/content/guides/tooling/postman/quick-start/2-configure-box-app.md
@@ -66,8 +66,11 @@ extra steps to set up.
   1. Go to the app's configuration by clicking **View Your App**.
   1. Scroll down to the **OAuth 2.0 redirect URI** configuration and set the
      **Redirect URI** to the value `https://developer.box.com/auth/callback`.
-  1. Optionally, scroll to the **Application Scopes** section of the same screen
+  1. Scroll to the **Application Scopes** section of the same screen
      and select any additional permissions you want to enable for this application.
+     **Your application must have at least one or more of the following scopes:** 
+     manage users,read all files and folders stored in Box, read and write all files 
+     and folders in Box.
   1. At the top of the page click the button to **Save Changes**
 </Choice>
 


### PR DESCRIPTION
# Description

DDOC-383: Adds minimum required scopes if you use your own application with postman quickstart

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch