### PR TITLE
Add redirect for new limited access app type

### DIFF
--- a/content/guides/applications/custom-apps/app-token-setup.md
+++ b/content/guides/applications/custom-apps/app-token-setup.md
@@ -11,7 +11,8 @@ required_guides:
   - authentication/select
   - applications/custom-apps
 related_resources: []
-alias_paths: []
+alias_paths:
+  - /guides/applications/limited-access-apps
 ---
 
 # Setup with App Tokens


### PR DESCRIPTION
# Description
The new auth experience flow will adjust the app type naming, and add a new link to https://developer.box.com/guides/applications/limited-access-apps/. This update adds a path alias to the https://developer.box.com/guides/applications/custom-apps/app-token-setup/ page so that the new URL will redirect to it.

Fixes # (issue)
Re `DDOC-375`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch
