### PR TITLE
Update token requirements for testing open with element

### DIFF
--- a/content/guides/embed/ui-elements/open-with.md
+++ b/content/guides/embed/ui-elements/open-with.md
@@ -279,9 +279,9 @@ curl -X DELETE https://api.box.com/2.0/app_integration_assignments/[APP_INTEGRAT
 <Message>
   # Access Token
 
-These demos may not fully function until you provide a valid access token. For
-testing purposes, you can use your temporary developer token. This will need
-to be updated under the JS tab in the demo.
+These demos may not fully function until you provide a valid access token under
+the JS tab of the demo. For the Open With element, you must provide a valid
+[Service Account][service-account] Access Token.
 
 </Message>
 
@@ -409,3 +409,4 @@ using `openWith.addListener('execute', callback)` and
 [tools]: https://community.box.com/t5/Box-Tools/ct-p/BoxEdit
 [custom-domains]: g://embed/ui-elements/custom-domains
 [safari]: https://community.box.com/t5/Using-Box-Tools/Installing-Box-Tools/ta-p/50143
+[service-account]: https://developer.box.com/guides/authentication/user-types/

--- a/content/guides/embed/ui-elements/open-with.md
+++ b/content/guides/embed/ui-elements/open-with.md
@@ -409,4 +409,4 @@ using `openWith.addListener('execute', callback)` and
 [tools]: https://community.box.com/t5/Box-Tools/ct-p/BoxEdit
 [custom-domains]: g://embed/ui-elements/custom-domains
 [safari]: https://community.box.com/t5/Using-Box-Tools/Installing-Box-Tools/ta-p/50143
-[service-account]: https://developer.box.com/guides/authentication/user-types/
+[service-account]: g://authentication/user-types/


### PR DESCRIPTION
# Description

The OpenWith Element requires use of a service account/app user token. It cannot be just any access token/developer token. 

Fixes DDOC-385

## Checklist

- [X ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own changes
- [ X] I have run `yarn lint` to make sure my changes pass all linters
- [ X] I have pulled the latest changes from the upstream developer branch
