### PR TITLE
Add explicit clarification that search does not support marker-based pagination

### DIFF
--- a/content/guides/search/4-pagination.md
+++ b/content/guides/search/4-pagination.md
@@ -7,7 +7,7 @@ required_guides: []
 # Pagination
 
 The search API supports offset-based pagination using the `offset` and `limit`
-query parameters.
+query parameters. Marker-based pagination is not supported.
 
 ## API Pagination
 


### PR DESCRIPTION
There's no mention of the more robust marker-based paging in Search documentation. State that it's not supported (yet)
