### PR TITLE
Remove language / guidance around use_index

### DIFF
--- a/content/guides/metadata/5-queries/1-create.md
+++ b/content/guides/metadata/5-queries/1-create.md
@@ -27,7 +27,6 @@ curl -X POST https://api.box.com/2.0/metadata_queries/execute_read \
          "metadata.enterprise_123456.contractTemplate.amount" 
        ],
        "ancestor_folder_id": "5555",
-       "use_index": "amountAsc",
        "order_by": [
          {
            "field_key": "amount",

--- a/content/guides/metadata/5-queries/4-errors.md
+++ b/content/guides/metadata/5-queries/4-errors.md
@@ -66,13 +66,9 @@ values will result in an error.
 ## Missing search index
 
 Due to scale considerations a metadata query might return a `HTTP 403` error
-when the metadata template has been applied to more than 10,000 files or folders.
-A search index can be created to resolve this error for a specific search query.
-
-If the number of metadata instances exceeds 10,000 then a metadata query request
-which does not include a suitable **index** in the `​use_index​` parameter will
-result in an error. The error will inform the caller to specify a suitable index
-as the argument to the `​use_index​` parameter.
+when the metadata template has been applied to more than 10,000 files or
+folders. A search index can be created to resolve this error for a specific
+search query.
 
 <CTA to='g://metadata/queries/indexes'>
   Learn more about creating and using indexes

--- a/content/guides/metadata/5-queries/6-indexes.md
+++ b/content/guides/metadata/5-queries/6-indexes.md
@@ -6,13 +6,9 @@ related_endpoints:
 # Indexes
 
 Due to scale considerations a metadata query might return a `HTTP 403` error
-when the metadata template has been applied to more than 10,000 files or folders.
-A search index can be created to resolve this error for a specific search query.
-
-If the number of metadata instances exceeds 10,000 then a metadata query request
-which does not include a suitable **index** in the `​use_index​` parameter will
-result in an error. The error will inform the caller to specify a suitable index
-as the argument to the `​use_index​` parameter.
+when the metadata template has been applied to more than 10,000 files or
+folders. A search index can be created to resolve this error for a specific
+search query.
 
 <Message notice>
   We expect this limit to be raised but not to be eliminated in the future.
@@ -28,16 +24,17 @@ to create an search index.
 
 </Message>
 
-To create an index, we will need to be informed of the intended query will be
-run including the exact values for the `from​`, `​query​`, and `​order_by​`
+To create an index, we will need to be informed of the intended query to be
+run, including the exact values for the `from​`, `​query​`, and `​order_by​`
 parameters of the request.
 
 An index will then be created and you will be provided with the the name of this
-index which then needs be used in the `​use_index​` parameter of a query
-request.
+index. If you prefer to specify a name for the index please provide that name
+upon requesting the index.
 
-If you prefer to specify a name for the index please provide that name upon
-requesting the index.
+Indexes are automatically applied during the metadata querying process when
+more than 10,000 files or folders are being searched. No further action beyond
+creating the index is needed to have the index applied. 
 
 <Message warning>
 
@@ -62,38 +59,4 @@ the information for the `​from`, `query`, and `order_by​` parameters.
 
 <!-- markdownlint-enable line-length -->
 
-## Query with an index
-
-To query with an index, use the name of the index we provided when performing
-your query as the value for the [`use_index`][use_index] parameter.
-
-```curl
-curl -X POST https://api.box.com/2.0/metadata_queries/execute_read \
-     -H 'Authorization: Bearer <ACCESS_TOKEN>" '
-     -H 'Content-Type: application/json'
-     -d '{
-       "from": "enterprise_123456.customerInfo",
-       "fields": ["name"],
-       "query": "accountNumber = :argAccountNum AND status = :argStatus",
-       "query_params": {
-         "argAccountNum": 12345,
-         "argStatus": "active"
-       },
-       "ancestor_folder_id": "5555",
-       "use_index": "yourIndexName",
-       "order_by": [
-         {
-           "field_key": "submissionDate",
-           "direction": "desc"
-         }
-       ]
-     }'
-```
-
-<Message warning>
-  The parameters used in a query must match exactly what was provided
-  for the creation of the index.
-</Message>
-
 [support]: https://community.box.com/t5/custom/page/page-id/BoxSearchLithiumTKB
-[use_index]: e://post-metadata-queries-execute-read/#param-use_index


### PR DESCRIPTION
# Description

`use_index` is no longer used during the metadata query process. When an index is created it will now be automatically applied in instances of searches with over 10k files/folders. The `use_index` parameter will now be ignored in API requests.

These changes remove guidance around using the `use_index` parameter.

Fixes `DDOC-395`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch