### PR TITLE
Ddoc 460 search keysafe

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -195,3 +195,5 @@ infixes
 styleguide
 csv
 weblink
+Keysafe
+e.g.

--- a/content/guides/search/1-indexing.md
+++ b/content/guides/search/1-indexing.md
@@ -98,8 +98,9 @@ language, Box’s indexing method, and document type.
 
 <Message warning>
   If your enterprise has full text search turned off
-  (e.g. Keysafe customers), characters within a document
-  cannot be searched.
+  (e.g. [Keysafe][keysafe] customers), characters within a document
+  cannot be searched. If you need to find out if full
+  text search is turned off, reach out to your account team.
 </Message>
 
 ## OCR Support
@@ -130,3 +131,4 @@ Searching the trash is available via the API by using the
 </CTA>
 
 [support]: p://support
+[keysafe]: https://www.box.com/security/keysafe

--- a/content/guides/search/1-indexing.md
+++ b/content/guides/search/1-indexing.md
@@ -96,6 +96,12 @@ The Box search index stores up to 10,000 bytes
 and above. This amount can vary from document to document because of
 language, Box’s indexing method, and document type.
 
+<Message warning>
+  If your enterprise has full text search turned off
+  (e.g. Keysafe customers), characters within a document
+  cannot be searched.
+</Message>
+
 ## OCR Support
 
 Box does not currently perform OCR on its documents.

--- a/content/guides/search/index.md
+++ b/content/guides/search/index.md
@@ -60,6 +60,12 @@ to get the issue resolved.
 
 </Message>
 
+<Message warning>
+  If your enterprise has full text search turned off
+  (e.g. Keysafe customers), characters within a document
+  cannot be searched.
+</Message>
+
 ## Comparison to Metadata Queries
 
 At the surface the search API seems very similar

--- a/content/guides/search/index.md
+++ b/content/guides/search/index.md
@@ -62,8 +62,9 @@ to get the issue resolved.
 
 <Message warning>
   If your enterprise has full text search turned off
-  (e.g. Keysafe customers), characters within a document
-  cannot be searched.
+  (e.g. [Keysafe][keysafe] customers), characters within a document
+  cannot be searched. If you need to find out if full
+  text search is turned off, reach out to your account team.
 </Message>
 
 ## Comparison to Metadata Queries
@@ -97,3 +98,4 @@ for relevance to a human user.
 [mdq_api]: e://post_metadata_queries_execute_read
 [search]: e://get_search
 [support]: p://support
+[keysafe]: https://www.box.com/security/keysafe


### PR DESCRIPTION
# Description

This adds a warning that lets developers know search will not return text results if full text search is turned off for the enterprise. 

Fixes # (issue)
Re `DDOC-#460` https://jira.inside-box.net/browse/DDOC-460
