### PR TITLE
Update callback URL

### DIFF
--- a/content/guides/tooling/postman/quick-start/2-configure-box-app.md
+++ b/content/guides/tooling/postman/quick-start/2-configure-box-app.md
@@ -74,7 +74,7 @@ extra steps to set up.
   4. Make sure your application uses **Standard OAuth 2.0** as the
      authentication method
   5. Scroll down to the **OAuth 2.0 redirect URI** configuration and set the
-     **Redirect URI** to the value `https://developer.box.com/auth/callback`.
+     **Redirect URI** to the value `https://box.dev/auth/callback`.
   6. Scroll down to the **Application Scopes** section to select your desired
      [permissions][scopes]. **Your application must have at least one or more**
      **of the following scopes:** manage users, read all files and folders


### PR DESCRIPTION
When developer.box.com went to box.dev, this callback url was not updated. If you use the previous callback url, the OAuth fails with an invalid callback url error.

# Description

Please include a summary of the change and which issue is fixed. 

If you are a Boxer, please also reference the related `DDOC` or `APIWG` tickets.
If you do not have a related `Jira` ticket and this is more than a bug fix, then
create one now.

Fixes # (issue)
Re `DDOC-#` (`Jira` ticket)
Re `APIWG-#` (`Jira` ticket)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own changes
- [ ] I have run `yarn lint` to make sure my changes pass all linters
- [ ] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
