### PR TITLE
Remove references to Adobe Sign

### DIFF
--- a/content/guides/embed/ui-elements/open-with.md
+++ b/content/guides/embed/ui-elements/open-with.md
@@ -28,7 +28,7 @@ The Element fetches information about enabled integrations using the
 Box API, and calls out to partner services. Users can then take action in these
 services, and the edited content will be automatically saved back to Box.
 
-The integrations included in the Open With Element are Adobe Sign, Google Suite,
+The integrations included in the Open With Element are Google Suite,
 and Box Edit. Additional information on the Google Suite integration can be
 found on the [Box Community site][community].
 
@@ -131,17 +131,27 @@ curl -X GET \
 
 ```json
 {
-  "type": "app_integration",
-  "id": "3282",
-  "app": {
-    "type": "app",
-    "id": "81713"
-  },
-  "name": "Sign with Adobe Sign",
-  "description": "Send your document for signature to Adobe Sign",
-  "executable_item_types": ["FILE"],
-  "restricted_extensions": ["pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx"],
-  "scoped_to": "root"
+   "type":"app_integration",
+   "id":"10897",
+   "app":{
+      "type":"app",
+      "id":"336417"
+   },
+   "name":"Edit with G Suite",
+   "description":"Securely manage your Google Docs, Sheets and Slides in Box",
+   "executable_item_types":[
+      "file"
+   ],
+   "restricted_extensions":[
+      "docx",
+      "gdoc",
+      "xlsx",
+      "gsheet",
+      "pptx",
+      "gslides",
+      "gslide"
+   ],
+   "scoped_to":"parent"
 }
 ```
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. 

JIRA Ticket: [DEVECO-4287](https://jira.inside-box.net/browse/DEVECO-4287)

Remove mention of Adobe Sign because it is no longer a supported integration.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
