### PR TITLE
DDOC-535 - update Preview SDK version references

### DIFF
--- a/content/guides/embed/ui-elements/installation.md
+++ b/content/guides/embed/ui-elements/installation.md
@@ -71,8 +71,8 @@ All the UI elements are also available directly from the Box CDN.
 | [Content Uploader](g://embed/ui-elements/uploader)   | `14.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/14.0.0/en-US/uploader.css`](https://cdn01.boxcdn.net/platform/elements/14.0.0/en-US/uploader.css)                              |
 |                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/14.0.0/en-US/uploader.js`](https://cdn01.boxcdn.net/platform/elements/14.0.0/en-US/uploader.js)                      |
 |                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/14.0.0/en-US/uploader.no.react.js`](https://cdn01.boxcdn.net/platform/elements/14.0.0/en-US/uploader.no.react.js) |
-| [Content Preview](g://embed/ui-elements/preview)     | `2.69.0` | CSS [`https://cdn01.boxcdn.net/platform/preview/2.69.0/en-US/preview.css`](https://cdn01.boxcdn.net/platform/preview/2.69.0/en-US/preview.css)                                  |
-|                                                      |          | JS [`https://cdn01.boxcdn.net/platform/preview/2.69.0/en-US/preview.js`](https://cdn01.boxcdn.net/platform/preview/2.69.0/en-US/preview.js)                                     |
+| [Content Preview](g://embed/ui-elements/preview)     | `2.81.0` | CSS [`https://cdn01.boxcdn.net/platform/preview/2.81.0/en-US/preview.css`](https://cdn01.boxcdn.net/platform/preview/2.81.0/en-US/preview.css)                                  |
+|                                                      |          | JS [`https://cdn01.boxcdn.net/platform/preview/2.81.0/en-US/preview.js`](https://cdn01.boxcdn.net/platform/preview/2.81.0/en-US/preview.js)                                     |
 
 Use these links to either download the elements code to your application's
 code, or embed them straight into your page from the CDN.
@@ -129,7 +129,7 @@ For Box Preview, the sample would look slightly different.
       var preview = new Box.Preview();
       preview.show("93392244621", "EqFyi1Yq1tD9mxY8F38sxDfp73pFd7FP", {
         container: ".preview-container",
-        showDownload: true
+        showDownload: true,
       });
     </script>
   </body>
@@ -178,7 +178,7 @@ steps.
 Either fork the repository and check out the version you want to serve or
 download the specific version as a zip.
 
-- Check out a specific version with `git checkout v2.69.0`.
+- Check out a specific version with `git checkout v2.81.0`.
 - Download a specific version as a zip from the [releases][preview-releases]
   page.
 
@@ -194,12 +194,12 @@ yarn install && yarn build:i18n && yarn build:prod
 
 Self-serve everything except for the `dev` folder from the `/dist` folder. You
 must not alter the folder structure and `third-party` needs to be in the same
-folder as `2.69.0`.
+folder as `2.81.0`.
 
 For example, if you self-host using a `box-assets` directory, these URLs must
 be accessible:
 
-- `https://cdn.YOUR_SITE.com/box-assets/2.69.0/en-US/preview.js`
+- `https://cdn.YOUR_SITE.com/box-assets/2.81.0/en-US/preview.js`
 - `https://cdn.YOUR_SITE.com/box-assets/third-party/text/0.114.0/papaparse.min.js`
 - `https://cdn.YOUR_SITE.com/box-assets/third-party/model3d/1.12.0/three.min.js`
 


### PR DESCRIPTION
https://jira.inside-box.net/browse/DDOC-535

# Description

DDOC-535 - update Preview SDK version references
https://jira.inside-box.net/browse/DDOC-535

bumped Preview SDK version from 2.69.0 to 2.81.0

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch
