### PR TITLE
DDOC-573: Fixed broken link to authentication section

### DIFF
--- a/content/guides/embed/ui-elements/installation.md
+++ b/content/guides/embed/ui-elements/installation.md
@@ -208,7 +208,9 @@ be accessible:
 In order to initialize any of the UI Elements, an application will need to
 provide a valid Access Token.
 
-<CTA to="authentication/select">Learn how to authenticate an application</CTA>
+<CTA to="g://authentication/select">
+  Learn how to authenticate an application
+</CTA>
 
 It is also recommended to [downscope][downscope] an Access Token before passing
 it into an insecure environment (the user's web browser).


### PR DESCRIPTION
# Description

Fixed the broken link in https://developer.box.com/guides/embed/ui-elements/installation/#authentication. It now points correctly to `guides/authentication/select`.

Fixes `DDOC-573`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch

