### PR TITLE
DDOC-555: Add note on redirect URI

### DIFF
--- a/content/guides/authentication/oauth2/oauth2-setup.md
+++ b/content/guides/authentication/oauth2/oauth2-setup.md
@@ -80,7 +80,12 @@ permit duplicate URIs to be saved.
   strictly match the one used during redirect. In addition, both new and
   existing applications, will gain the ability to add multiple redirect URIs.
 
-  If you configured multiple redirect URIs for the application, the authorization URL must include the `redirect_uri` parameter matching one of the URIs configured in the devloper console. If the parameter is not specified, the user will see a `redirect_uri_missing` error and will not be redirected back to the app after granting application access.
+  If you configured multiple redirect URIs for the application, 
+  the authorization URL must include the `redirect_uri` parameter matching one
+  of the URIs configured in the developer console. 
+  If the parameter is not specified, the user will see a `redirect_uri_missing`
+  error and will not be redirected back to the app after granting application
+  access.
 
   For existing applications, the deadline to make changes to this URL to avoid
   service disruption is May 13, 2022.

--- a/content/guides/authentication/oauth2/oauth2-setup.md
+++ b/content/guides/authentication/oauth2/oauth2-setup.md
@@ -80,6 +80,8 @@ permit duplicate URIs to be saved.
   strictly match the one used during redirect. In addition, both new and
   existing applications, will gain the ability to add multiple redirect URIs.
 
+  If you configured multiple redirect URIs for the application, the authorization URL must include the `redirect_uri` parameter matching one of the URIs configured in the devloper console. If the parameter is not specified, the user will see a `redirect_uri_missing` error and will not be redirected back to the app after granting application access.
+
   For existing applications, the deadline to make changes to this URL to avoid
   service disruption is May 13, 2022.
 </Message>

--- a/content/guides/authentication/oauth2/with-sdk.md
+++ b/content/guides/authentication/oauth2/with-sdk.md
@@ -118,7 +118,11 @@ Next, redirect the user to the authorization URL. Most of the SDKs support a
 way to get the authorization URL for an SDK client.
 
 <Message warning>
-If you configured multiple redirect URIs for the application, the authorization URL must include the `redirect_uri` parameter matching one of the URIs configured in the devloper console. If the parameter is not specified, the user will see a `redirect_uri_missing` error and will not be redirected back to the app after granting application access.
+If you configured multiple redirect URIs for the application, the authorization
+URL must include the `redirect_uri` parameter matching one of the URIs
+configured in the developer console. If the parameter is not specified, the
+user will see a `redirect_uri_missing` error and will not be redirected back to
+the app after granting application access.
 </Message>
 
 <Tabs>
@@ -183,7 +187,9 @@ https://account.box.com/api/oauth2/authorize?client_id=[CLIENT_ID]&redirect_uri=
 <!-- markdownlint-enable line-length -->
 
 <Message>
- Additional query parameters can be passed along when redirecting the user to limit down the scope, or pass along some extra state. See the [reference documentation](endpoint://get-authorize) for more information.
+ Additional query parameters can be passed along when redirecting the user to
+ limit down the scope, or pass along some extra state. See the [reference
+ documentation](endpoint://get-authorize) for more information.
 </Message>
 
 <Message type='tip'>

--- a/content/guides/authentication/oauth2/with-sdk.md
+++ b/content/guides/authentication/oauth2/with-sdk.md
@@ -117,6 +117,10 @@ var sdk = new BoxSDK({
 Next, redirect the user to the authorization URL. Most of the SDKs support a
 way to get the authorization URL for an SDK client.
 
+<Message warning>
+If you configured multiple redirect URIs for the application, the authorization URL must include the `redirect_uri` parameter matching one of the URIs configured in the devloper console. If the parameter is not specified, the user will see a `redirect_uri_missing` error and will not be redirected back to the app after granting application access.
+</Message>
+
 <Tabs>
   <Tab title='.NET'>
 
@@ -179,9 +183,7 @@ https://account.box.com/api/oauth2/authorize?client_id=[CLIENT_ID]&redirect_uri=
 <!-- markdownlint-enable line-length -->
 
 <Message>
-  Additional query parameters can be passed along when redirecting the user to
-  limit down the scope, or pass along some extra state. See the [reference
-  documentation](endpoint://get-authorize) for more information.
+ Additional query parameters can be passed along when redirecting the user to limit down the scope, or pass along some extra state. See the [reference documentation](endpoint://get-authorize) for more information.
 </Message>
 
 <Message type='tip'>

--- a/content/guides/authentication/oauth2/without-sdk.md
+++ b/content/guides/authentication/oauth2/without-sdk.md
@@ -63,6 +63,14 @@ An [authorization URL][auth] is comprised of the following parameters:
 | [`RESPONSE_TYPE`][co]| Required     | Always set to `code`                                                                                   |
 | [`STATE`][st]        | Recommended  | Protects against cross-site request forgery                                                            |
 
+<Message warning>
+If you configured multiple redirect URIs for the application, the authorization
+URL must include the `redirect_uri` parameter matching one of the URIs
+configured in the developer console. If the parameter is not specified, the
+user will see a `redirect_uri_missing` error and will not be redirected back to
+the app.
+</Message>
+
 <!-- markdownlint-enable line-length -->
 
 At the minimum this URL will always use the format:
@@ -204,14 +212,6 @@ approve the application to take actions on their behalf.
 When the user accepts this request by clicking **Grant access to Box**, the
 browser will redirect to the configured redirect URL with a query parameter
 containing a short-lived authorization code. 
-
-<Message warning>
-If you configured multiple redirect URIs for the application, the authorization
-URL must include the `redirect_uri` parameter matching one of the URIs
-configured in the developer console. If the parameter is not specified, the
-user will see a `redirect_uri_missing` error and will not be redirected back to
-the app.
-</Message>
 
 ```curl
 https://your.domain.com/path?code=1234567

--- a/content/guides/authentication/oauth2/without-sdk.md
+++ b/content/guides/authentication/oauth2/without-sdk.md
@@ -205,6 +205,10 @@ When the user accepts this request by clicking **Grant access to Box**, the
 browser will redirect to the configured redirect URL with a query parameter
 containing a short-lived authorization code. 
 
+<Message warning>
+If you configured multiple redirect URIs for the application, the authorization URL must include the `redirect_uri` parameter matching one of the URIs configured in the developer console. If the parameter is not specified, the user will see a `redirect_uri_missing` error and will not be redirected back to the app.
+</Message>
+
 ```curl
 https://your.domain.com/path?code=1234567
 ```

--- a/content/guides/authentication/oauth2/without-sdk.md
+++ b/content/guides/authentication/oauth2/without-sdk.md
@@ -206,7 +206,11 @@ browser will redirect to the configured redirect URL with a query parameter
 containing a short-lived authorization code. 
 
 <Message warning>
-If you configured multiple redirect URIs for the application, the authorization URL must include the `redirect_uri` parameter matching one of the URIs configured in the developer console. If the parameter is not specified, the user will see a `redirect_uri_missing` error and will not be redirected back to the app.
+If you configured multiple redirect URIs for the application, the authorization
+URL must include the `redirect_uri` parameter matching one of the URIs
+configured in the developer console. If the parameter is not specified, the
+user will see a `redirect_uri_missing` error and will not be redirected back to
+the app.
 </Message>
 
 ```curl


### PR DESCRIPTION
# Description

Added a note (warning) on specifying the `redirect_uri` parameter to the following docs:

- https://staging.developer.box.com/guides/authentication/oauth2/oauth2-setup/
- https://staging.developer.box.com/guides/authentication/oauth2/with-sdk/
- https://staging.developer.box.com/guides/authentication/oauth2/without-sdk/

Fixes DDOC-555

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own changes
- [ ] I have run `yarn lint` to make sure my changes pass all linters
- [ ] I have pulled the latest changes from the upstream developer branch
