### PR TITLE
removing cca warning box

### DIFF
--- a/content/guides/authentication/client-credentials/index.md
+++ b/content/guides/authentication/client-credentials/index.md
@@ -56,15 +56,9 @@ If you would like to authenticate as a Managed User:
 
 <Samples id='x_auth' variant='with_client_credentials' ></Samples>
 
-<Message notice>
-
-Our `.NET` and `Java` SDKs currently support Client Credentials. More SDKS will
-gain support soon.
-
-</Message>
-    
 ## Common Errors
-    
+
+<!--alex ignore invalid-->    
 ### Grant credentials are invalid
 
 This error indicates either: 


### PR DESCRIPTION
# Description

Remove message box under sample code section - "Our .NET and Java SDKs currently support Client Credentials. More SDKS will gain support soon.".
All the languages now support CCG, except Android which is in maintenance mode.


Fixes # (issue)
DDOC-588 (Update Client credentials grant page)

## Checklist

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own changes
- [ x] I have run `yarn lint` to make sure my changes pass all linters
- [ x] I have pulled the latest changes from the upstream developer branch

