### PR TITLE
Ddoc 604/sign webhooks

### DIFF
--- a/content/guides/box-sign/index.md
+++ b/content/guides/box-sign/index.md
@@ -42,6 +42,10 @@ Box Sign's endpoints.
 
 Please see our [events guide][eg] for more information.
 
+## Webhooks
+
+Please see our [webhooks guide][wh] for more information.
+
 ## Rate Limits
 
 Please see our [rate limit guide][ratelimit] for more information.
@@ -67,3 +71,4 @@ production content.
 [sandbox]: https://support.box.com/hc/en-us/articles/360043697274-Managing-developer-sandboxes-for-Box-admins 
 <!-- i18n-disable localize-links -->
 [eg]: g://events/event-triggers/sign-events
+[wh]: g://webhooks/triggers#sign-request

--- a/content/guides/webhooks/triggers.md
+++ b/content/guides/webhooks/triggers.md
@@ -69,8 +69,10 @@ available for folders.
 | `SIGN_REQUEST.SIGNED`               | A sign request is completed                                   |
 | `SIGN_REQUEST.DECLINED`             | A sign request is declined                                    |
 | `SIGN_REQUEST.EXPIRED`              | A sign request is expired                                     |
-| `SIGN_REQUEST.SIGNER_EMAIL_BOUNCED` | A sign request recipient email notification was not delivered |
+
+<!-- | `SIGN_REQUEST.SIGNER_EMAIL_BOUNCED` | A sign request recipient email notification was not delivered | -->
 <!-- markdownlint-enable line-length -->
+
 ## V1
 
 The follow is a list of events that can be configured to trigger a v1 webhook. 

--- a/content/guides/webhooks/triggers.md
+++ b/content/guides/webhooks/triggers.md
@@ -14,6 +14,8 @@ alias_paths:
 
 ## V2
 
+### Files and Folders
+
 The following is a list of events that can be configured to trigger a v2
 webhook. Some events are only available for files, while others are only
 available for folders.
@@ -59,6 +61,16 @@ available for folders.
 | `WEBHOOK.DELETED`           | When a webhook is deleted                                                                                           | No    | No      |
 <!-- markdownlint-enable line-length -->
 
+### Sign request
+
+<!-- markdownlint-disable line-length -->
+| Event                               | Triggered                                                     |
+|-------------------------------------|---------------------------------------------------------------|
+| `SIGN_REQUEST.SIGNED`               | A sign request is completed                                   |
+| `SIGN_REQUEST.DECLINED`             | A sign request is declined                                    |
+| `SIGN_REQUEST.EXPIRED`              | A sign request is expired                                     |
+| `SIGN_REQUEST.SIGNER_EMAIL_BOUNCED` | A sign request recipient email notification was not delivered |
+<!-- markdownlint-enable line-length -->
 ## V1
 
 The follow is a list of events that can be configured to trigger a v1 webhook. 


### PR DESCRIPTION
Documentation for Box Sign Webhooks

Changes in Staging:

Guides -> Box Sign -> [Webhooks](https://staging.developer.box.com/guides/box-sign/#webhooks)
Guides -> Webhooks -> [Sign request](https://staging.developer.box.com/guides/webhooks/triggers/#sign-request)
API Reference -> Webhooks -> Webhook V2 Payload -> [trigger](https://staging.developer.box.com/reference/resources/webhook-invocation/#param-trigger)

Fixes # (issue)
Re `DDOC-604` 

## Checklist

- [X ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own changes
- [X] I have run `yarn lint` to make sure my changes pass all linters
- [X] I have pulled the latest changes from the upstream developer branch


