### PR TITLE
Add configurable notification bar

### DIFF
--- a/content/microcopy/headers.yml
+++ b/content/microcopy/headers.yml
@@ -104,3 +104,24 @@ secondary:
     // elsewhere: |-
       A short title for the dropdown to select an external link on mobile
     elsewhere: Elsewhere
+
+  notifications:
+    // display: |-
+      A boolean that determines whether to show the orange notification bar in the header
+    display: true
+
+    // message: |-
+      The content of the notification
+    message: Join the first BoxWorks Hackathon 4Good - customers, partners and the developer community are welcome to participate in the 48 hour Hack to benefit a nonprofit Box customer.
+
+    // href: |-
+      The link to navigate to when the CTA is clicked
+    href: "https://box.com/hack4good"
+
+    // cta: |-
+      The text of the CTA
+    cta: Learn more
+
+    // ttl: |-
+      The number of seconds to display the message. Should always be 0 unless you want to autohide.
+    ttl: 0

--- a/content/microcopy/headers.yml
+++ b/content/microcopy/headers.yml
@@ -108,7 +108,7 @@ secondary:
   notifications:
     // display: |-
       A boolean that determines whether to show the orange notification bar in the header
-    display: true
+    display: "false"
 
     // message: |-
       The content of the notification

--- a/content/microcopy/headers.yml
+++ b/content/microcopy/headers.yml
@@ -107,12 +107,16 @@ secondary:
 
   notifications:
     // display: |-
-      A boolean that determines whether to show the orange notification bar in the header
+      A boolean that determines whether to show the orange notification bar
+      in the header. Must be "true" or "false"
     display: "false"
 
     // message: |-
       The content of the notification
-    message: Join the first BoxWorks Hackathon 4Good - customers, partners and the developer community are welcome to participate in the 48 hour Hack to benefit a nonprofit Box customer.
+    message: >
+      Join the first BoxWorks Hackathon 4Good - customers,
+      partners and the developer community are welcome to participate
+      in the 48 hour Hack to benefit a nonprofit Box customer.
 
     // href: |-
       The link to navigate to when the CTA is clicked
@@ -123,5 +127,6 @@ secondary:
     cta: Learn more
 
     // ttl: |-
-      The number of seconds to display the message. Should always be 0 unless you want to autohide.
-    ttl: 0
+      The number of seconds to display the message. Should always
+      be 0 unless you want to autohide.
+    ttl: "0"


### PR DESCRIPTION
# Description

Adding a configurable and hide-able notification bar, inline with the orange notification bar at box.com. 

## Checklist

- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own changes
- [ X] I have run `yarn lint` to make sure my changes pass all linters
- [ X] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
