### PR TITLE
DDOC-643: Add ready-sign-link field for signer events

### DIFF
--- a/content/guides/events/event-triggers/sign-events.md
+++ b/content/guides/events/event-triggers/sign-events.md
@@ -299,6 +299,9 @@ The`additional_details` payload will provide the following details:
         },
         "template": null,
         "batch_send": null,
+        "ready_sign_link": {
+            "id": "aaae45bb-e89b-12d3-a456-426614174000"
+        }
         "sender_message": {
             "subject": "",
             "message": ""
@@ -350,6 +353,9 @@ The`additional_details` payload will provide the following details:
         },
         "template": null,
         "batch_send": null,
+        "ready_sign_link": {
+            "id": "aaae45bb-e89b-12d3-a456-426614174000"
+        },
         "sender_message": {
             "subject": "",
             "message": ""
@@ -398,6 +404,9 @@ signing document.
         },
         "template": null,
         "batch_send": null,
+        "ready_sign_link": {
+            "id": "aaae45bb-e89b-12d3-a456-426614174000"
+        },
         "sender_message": {
             "subject": "",
             "message": ""
@@ -450,6 +459,9 @@ signing document.
         },
         "template": null,
         "batch_send": null,
+        "ready_sign_link": {
+            "id": "aaae45bb-e89b-12d3-a456-426614174000"
+        },
         "sender_message": {
             "subject": "Can you please sign this document?",
             "message": "This document shows the terms agreed to on the phone."
@@ -504,6 +516,9 @@ The`additional_details` payload will provide the following details:
         },
         "template": null,
         "batch_send": null,
+        "ready_sign_link": {
+            "id": "aaae45bb-e89b-12d3-a456-426614174000"
+        },
         "sender_message": {
             "subject": "Can you please sign this document?",
             "message": "This document shows the terms agreed to on the phone."
@@ -554,6 +569,9 @@ The`additional_details` payload will provide the following details:
         },
         "template": null,
         "batch_send": null,
+        "ready_sign_link": {
+            "id": "aaae45bb-e89b-12d3-a456-426614174000"
+        },
         "sender_message": {
             "subject": "",
             "message": ""


### PR DESCRIPTION
# Description

Added ready-sign-link field to the additional_details payload for signer events.
Preview: https://staging.developer.box.com/guides/events/event-triggers/sign-events/#signer-events

Fixes DDOC-643
