### PR TITLE
docs: add sample scripts link to CLI OAuth guide

### DIFF
--- a/content/guides/cli/quick-start/6-next-steps.md
+++ b/content/guides/cli/quick-start/6-next-steps.md
@@ -22,7 +22,7 @@ To take the next step, the following resources are recommended:
 1. Review all [commands][commands].
 2. Review [token cache][cache] settings.
 3. Review [autocomplete][ac] settings.
-4. Review [CLI Sample scripts][sample-scripts].
+4. Review [CLI sample scripts][sample-scripts].
 
 [one]: g://cli/quick-start/create-oauth-app/
 [two]: g://cli/quick-start/install-and-configure/

--- a/content/guides/cli/quick-start/6-next-steps.md
+++ b/content/guides/cli/quick-start/6-next-steps.md
@@ -22,6 +22,7 @@ To take the next step, the following resources are recommended:
 1. Review all [commands][commands].
 2. Review [token cache][cache] settings.
 3. Review [autocomplete][ac] settings.
+4. Review [CLI Sample scripts][sample-scripts].
 
 [one]: g://cli/quick-start/create-oauth-app/
 [two]: g://cli/quick-start/install-and-configure/
@@ -31,3 +32,4 @@ To take the next step, the following resources are recommended:
 [cache]: https://github.com/box/boxcli/blob/master/docs/configure.md#box-configureenvironmentsupdate-name
 [ac]: https://github.com/box/boxcli/blob/master/docs/autocomplete.md
 [commands]: https://github.com/box/boxcli#command-topics
+[sample-scripts]: https://developer.box.com/guides/cli/scripts/


### PR DESCRIPTION
# Description

In the CLI OAuth set up guide as a last step added link to [CLI Sample scripts](https://developer.box.com/guides/cli/scripts/)
