### PR TITLE
DDOC-656: Improve upload part API guide

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -238,3 +238,5 @@ Group1
 Group2
 Group3
 viewer_uploader
+openSSL
+base-64

--- a/content/guides/uploads/chunked/upload-part.md
+++ b/content/guides/uploads/chunked/upload-part.md
@@ -14,32 +14,111 @@ alias_paths: []
 
 # Upload Part
 
-To upload a part, first [create an upload session][createsession]. The resulting
+When you want to upload a large file, 
+you can split it into smaller parts and 
+upload them using the Upload Part API.
+
+## Create Upload Session
+
+First, [create an upload session][createsession]. The resulting
 object defines the size of each part and the number of parts to upload.
 
-Then, upload the bytes for the part you want to upload, specifying the byte
-range for the part, as well as the `SHA` digest to ensure the content is
+<!-- markdownlint-disable line-length -->
+
+```json
+{
+  "id": "F971964745A5CD0C001BBE4E58196BFD",
+  "type": "upload_session",
+  "session_expires_at": "2012-12-12T10:53:43-08:00",
+  "part_size": 1024,
+  "total_parts": 1000,
+  "num_parts_processed": 455,
+  "session_endpoints": {
+    "upload_part": "https://upload.box.com/api/2.0/files/upload_sessions/F971964745A5CD0C001BBE4E58196BFD",
+    "commit": "https://upload.box.com/api/2.0/files/upload_sessions/F971964745A5CD0C001BBE4E58196BFD/commit",
+    "abort": "https://upload.box.com/api/2.0/files/upload_sessions/F971964745A5CD0C001BBE4E58196BFD",
+    "list_parts": "https://upload.box.com/api/2.0/files/upload_sessions/F971964745A5CD0C001BBE4E58196BFD/parts",
+    "status": "https://upload.box.com/api/2.0/files/upload_sessions/F971964745A5CD0C001BBE4E58196BFD",
+    "log_event": "https://upload.box.com/api/2.0/files/upload_sessions/F971964745A5CD0C001BBE4E58196BFD/log"
+  }
+}
+```
+
+<!-- markdownlint-enable line-length -->
+
+## Split File
+
+Split the file to parts you will upload. 
+If you want to use the API from the command line, 
+use the `split` command:
+
+```bash
+split -b <PART_SIZE> <FILE_NAME> <YOUR_PART_NAME>
+```
+
+For example:
+
+```bash
+split -b 8388608 video.mp3 videopart
+```
+
+This will result in your file divided into several files.
+
+## Upload Part
+
+Upload the bytes for the part you want to upload, specifying the byte
+range for the part and the `SHA` digest to ensure the content is
 uploaded correctly.
 
 <Samples id='put_files_upload_sessions_id' />
 
-## Part Size
+### Content Range 
 
-Each part’s size must be exactly equal in size to the part size specified in the
-upload session that was created. One exception is the last part of the file, as
-this is allowed to be smaller.
+Each part’s size must be exactly equal in size to the part size 
+specified in the upload session that you created. 
+One exception is the last part of the file, as
+this can be smaller. The `Content-Range` parameter 
+definition follows this pattern:
 
-<Message>
-  # Tip
+```yaml
+  -H "Content-Range: bytes <LOWER_BOUND>-<HIGHER_BOUND>/<TOTAL_SIZE>"
+```
 
-  As a result, the lower bound of each part's byte range should be
-  a multiple of the part size.
-</Message>
+When providing the value for `Content-Range`, remember that:
+
+* The lower bound of each part's byte range must be a multiple of the part size.
+* The higher bound must be a multiple of the part size - 1.  
+
+For example, if the part size is `8388608`, 
+the content range for the first two parts will be:
+
+```yaml
+- H "Content-Range : bytes 0-8388607/32127641" \ ## first part
+- H "Content-Range : bytes 8388608-16777215/32127641" \ ## second part
+```
+
+### Get SHA Digest
+
+To get the value for the `SHA` digest,
+use the following openSSL command
+to encode the file part:
+
+```bash
+openssl sha1 -binary <FILE_PART_NAME> | base64
+```
+
+For example:
+
+```bash
+openssl sha1 -binary videoparta | base64
+```
+
+The result is a base-64 encoded message used to verify the upload.
 
 ## Response
 
-After each upload, the resulting response includes the ID and SHA of the part
-uploaded.
+After each upload, the resulting response includes 
+the `ID` and `SHA` of the part uploaded.
 
 ```json
 {
@@ -51,27 +130,28 @@ uploaded.
 ```
 
 <Message warning>
-  The client is recommended to log keep all the JSON responses from all part
+  Keep all the JSON responses from all part
   uploads as they are needed to [commit the session][commit].
 </Message>
 
 ## Range Overlap
 
 If a part upload request fails with any error code
-`range_overlaps_existing_part` then the application made a mistake in cutting up
-the file into parts and tried to upload a part into a range that already had
-content uploaded for it. The application should assume that this last part was not
-persisted to the session.
+`range_overlaps_existing_part` then the application 
+made a mistake in cutting up the file into parts 
+and tried to upload a part into a range that already had
+content uploaded for it. The application should assume 
+that this last part was not persisted to the session.
 
 ## Parallel uploads
 
-Although parts can be uploaded in parallel, parts **should** be uploaded in
+Although you can upload the parts in parallel, try to upload them in
 order as much as is possible. Parts with a lower byte offset should be uploaded
 before parts with a higher byte offset.
 
 The recommended approach is to upload 3 to 5 parts in parallel from a queue
-of parts, ordered by byte offset. If a part upload fails, it should be retried
-before later parts are uploaded.
+of parts, ordered by byte offset. If a part upload fails, retry it
+before you upload further parts.
 
 [commit]: g://uploads/chunked/commit-session
 [createsession]: g://uploads/chunked/create-session

--- a/content/guides/uploads/chunked/upload-part.md
+++ b/content/guides/uploads/chunked/upload-part.md
@@ -48,8 +48,8 @@ object defines the size of each part and the number of parts to upload.
 
 ## Split File
 
-Split the file to parts you will upload. 
-If you want to use the API from the command line, 
+Split the file into parts to be uploaded. 
+If you want to use the command line, 
 use the `split` command:
 
 ```bash
@@ -63,6 +63,24 @@ split -b 8388608 video.mp3 videopart
 ```
 
 This will result in your file divided into several files.
+
+### Get SHA Digest
+
+To get the value for the `SHA` digest,
+use the following openSSL command
+to encode the file part:
+
+```bash
+openssl sha1 -binary <FILE_PART_NAME> | base64
+```
+
+For example:
+
+```bash
+openssl sha1 -binary videoparta | base64
+```
+
+The result is a base-64 encoded message used to verify the upload.
 
 ## Upload Part
 
@@ -96,24 +114,6 @@ the content range for the first two parts will be:
 - H "Content-Range : bytes 0-8388607/32127641" \ ## first part
 - H "Content-Range : bytes 8388608-16777215/32127641" \ ## second part
 ```
-
-### Get SHA Digest
-
-To get the value for the `SHA` digest,
-use the following openSSL command
-to encode the file part:
-
-```bash
-openssl sha1 -binary <FILE_PART_NAME> | base64
-```
-
-For example:
-
-```bash
-openssl sha1 -binary videoparta | base64
-```
-
-The result is a base-64 encoded message used to verify the upload.
 
 ## Response
 


### PR DESCRIPTION
# Description

Added improvements to the upload part guide: https://developer.box.com/guides/uploads/chunked/upload-part/

- added info on how to split the file into chunks with the split command
- added info on how to define the `content-range` parameter
- added info on how to obtain the SHA digest
- improved the structure of the doc

Part of DDOC-656
Preview: https://staging.developer.box.com/guides/uploads/chunked/upload-part/
