### PR TITLE
Update DryRun mode in CLI example scripts

### DIFF
--- a/content/guides/cli/scripts/deprovision-users.md
+++ b/content/guides/cli/scripts/deprovision-users.md
@@ -136,7 +136,7 @@ output or a similar one.
 
 To run the script in a simulation mode, 
 add the `DryRun` boolean flag.
-Dry run doesn't mean that API calls won't be made
+Dry run doesn't mean that API calls won't be made, 
 but that create/update/delete calls will be skipped.
 
 ```bash

--- a/content/guides/cli/scripts/deprovision-users.md
+++ b/content/guides/cli/scripts/deprovision-users.md
@@ -131,6 +131,17 @@ output or a similar one.
     Deleted user 19927131476
     Deleted employee Managed User 1
    ```
+   
+### Optional flags
+
+To run the script in a simulation mode, 
+add the `DryRun` boolean flag.
+Dry run doesn't mean that API calls won't be made,
+instead, any create/update/delete calls will be skipped.
+
+```bash
+./Users_Deprovision.ps1 -DryRun
+```
 
 ## Logging
 

--- a/content/guides/cli/scripts/deprovision-users.md
+++ b/content/guides/cli/scripts/deprovision-users.md
@@ -136,8 +136,8 @@ output or a similar one.
 
 To run the script in a simulation mode, 
 add the `DryRun` boolean flag.
-Dry run doesn't mean that API calls won't be made,
-instead, any create/update/delete calls will be skipped.
+Dry run doesn't mean that API calls won't be made
+but that create/update/delete calls will be skipped.
 
 ```bash
 ./Users_Deprovision.ps1 -DryRun

--- a/content/guides/cli/scripts/user-zones-mass-update.md
+++ b/content/guides/cli/scripts/user-zones-mass-update.md
@@ -159,7 +159,7 @@ Run the script.
 
 To run the script in a simulation mode, 
 add the `DryRun` boolean flag.
-Dry run doesn't mean that API calls won't be made but that any create/update/delete calls will be skipped.
+Dry run doesn't mean that API calls won't be made, but that any create/update/delete calls will be skipped.
 
 ```bash
 ./Mass_Update_User_Zones.ps1 -DryRun

--- a/content/guides/cli/scripts/user-zones-mass-update.md
+++ b/content/guides/cli/scripts/user-zones-mass-update.md
@@ -107,7 +107,7 @@ The `.csv` file must have two columns with the following headers: **Email** and 
   ```
   
 <message>
-  Consult the BC or CSM contact to get the IDs corresponding to the zones enabled in a specific enterprise.
+  Consult the Box Consulting or Customer Success manager to get the IDs corresponding to the zones enabled in a specific enterprise.
 </message>
  
 A sample input `.csv` file containing emails and zone names is provided with this script. Its content looks as follows:
@@ -126,7 +126,7 @@ Set the `UserZonesUpdatePath` to point to your `.csv` file.
 $UserZonesUpdatePath = "./your_file_name.csv"
 ```
 
-Update the `adminEmail` to the admin or `co-admin` login email address of    the account the script will use to make zone assignments. 
+Update the `adminEmail` to the admin or `co-admin` login email address of the account the script will use to make zone assignments. 
 If you don't specify this value, the script will prompt you for it.
 
 ```bash
@@ -151,17 +151,19 @@ PS /home/rvb/box-cli/examples/Mass Update User Zones>
 
 Run the script.
    
-   ```bash
-    ./Mass_Update_User_Zones.ps1
-   ```
+```bash
+./Mass_Update_User_Zones.ps1
+```
 
 ### Optional flags
 
 To run the script in a simulation mode, 
-add the `simulate` boolean flag.
+add the `DryRun` boolean flag.
+Dry run doesn't mean that API calls won't be made,
+instead, any create/update/delete calls will be skipped.
 
 ```bash
-./Mass_Update_User_Zones.ps1 -simulate
+./Mass_Update_User_Zones.ps1 -DryRun
 ```
 
 ## Logging

--- a/content/guides/cli/scripts/user-zones-mass-update.md
+++ b/content/guides/cli/scripts/user-zones-mass-update.md
@@ -159,8 +159,7 @@ Run the script.
 
 To run the script in a simulation mode, 
 add the `DryRun` boolean flag.
-Dry run doesn't mean that API calls won't be made,
-instead, any create/update/delete calls will be skipped.
+Dry run doesn't mean that API calls won't be made but that any create/update/delete calls will be skipped.
 
 ```bash
 ./Mass_Update_User_Zones.ps1 -DryRun


### PR DESCRIPTION
# Description

In the CLI sample scripts we added `DryRun` flag for [user deprovisioning](https://github.com/box/boxcli/tree/main/examples/User%20Deprovisioning) script and changed `simulation` flag to `DryRun` in [User Zones update ](https://github.com/box/boxcli/tree/main/examples/Mass%20Update%20User%20Zones)script.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [ ] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch


