### PR TITLE
docs: Update the default folder name

### DIFF
--- a/content/guides/cli/quick-start/5-powershell-script-templates.md
+++ b/content/guides/cli/quick-start/5-powershell-script-templates.md
@@ -204,7 +204,7 @@ $PersonalFolderParentID = ""
 
   ```bash
   PS > ./Users_Create_Provision.ps1 -EmployeeList ./Employees_1.csv `
-      -LocalUploadPath ./OnboardingLocalUpload `
+      -LocalUploadPath ./PersonalLocalUpload `
       -PersonalFolderSlug "Personal Folder" `
       -PersonalFolderParentID 123456789
 


### PR DESCRIPTION
Box CLI script by default has folder called `PersonalLocalUpload` See details - https://github.com/box/boxcli/tree/main/examples/User%20Creation%20%26%20Provisioning