### PR TITLE
[Fix] Remove slash in alias

### DIFF
--- a/content/guides/tooling/postman/index.md
+++ b/content/guides/tooling/postman/index.md
@@ -7,7 +7,7 @@ required_guides: []
 related_resources: []
 alias_paths:
   - /docs/box-postman-collection
-  - /guides/tooling/postman/legacy/
+  - /guides/tooling/postman/legacy
 ---
 
 # Postman Collection


### PR DESCRIPTION
# Description

Remove reduntant slash in alias to fix the link.
