### PR TITLE
DDOC-599: Server-side actions EOL (documentation updates)

### DIFF
--- a/content/guides/applications/web-app-integrations/configure.md
+++ b/content/guides/applications/web-app-integrations/configure.md
@@ -16,12 +16,20 @@ notes: |-
 
 This guide explains how to set up a Web App Integration with a Custom App.
 
-## 1. Create an OAuth 2.0 Application
+<message type='warning'>
+Server-side integration is no longer supported. 
+This means your applications
+will still be working, 
+but you won't be able to edit their
+configuration.
+</message>
+
+## Create an OAuth 2.0 Application
 
 Navigate to the [Developer Console][devconsole] and create a [Custom App][ca]
 that leverages [OAuth 2.0 authentication][custom-oauth2].
 
-## 2. Create a New Integration
+## Create a New Integration
 
 Then, navigate to the **Integrations** tab and click 
 **Create a Web App Integration**.
@@ -30,7 +38,7 @@ Then, navigate to the **Integrations** tab and click
   ![Integration Tab](../images/create_integration.png)
 </ImageFrame>
 
-## 3. Configure Integration
+## Configure Integration
 
 To configure the integration, follow the guidance below for each value.
 
@@ -58,7 +66,7 @@ To configure the integration, follow the guidance below for each value.
 | Field | Description |
 |--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| 
 | Client Callback URL | Handles additional callback requests from Box after the primary request with Popup Integrations. If the application specifies a file parameter in the REST method, the preliminary callback URL cannot originate from the client. As a result, a second request must be made from the client to your server so the server can send the necessary interface to the user. |
-| User Experience | Determines whether the integration is a [Popup][pu] or [Server-Side][ssi] Integration. |
+| User Experience | Informs that the integration will open in a new window.|
 | New window settings | Determines if the application opens in a new tab. |
 
 <!-- markdownlint-enable line-length -->
@@ -68,9 +76,16 @@ To configure the integration, follow the guidance below for each value.
 The **Callback Parameters** section configures the parameters that Box sends to
 the callback URL when a user accepts a confirmation prompt. If this setting is 
 not configured, Box does not send any parameters to the callback URL.
-To add a parameter, you need to select the **Method**, 
+To add a parameter, select the **Method**, 
 specify the **Parameter name** and add a **Parameter value**. 
-Available methods are **Get**, **Post** and **File**. 
+Available methods are **Get** and **Post**. 
+
+<message type='warning'>
+**File** method is no longer supported. I you already used this method,
+you cannot edit its values. You can change **File** method to **Get**
+or **Post**, but you cannot undo this action.
+</message>
+
 For example: **Get - `userid` - `#user_id#`**.
 
 The following parameter values are available.

--- a/content/guides/applications/web-app-integrations/configure.md
+++ b/content/guides/applications/web-app-integrations/configure.md
@@ -18,10 +18,10 @@ This guide explains how to set up a Web App Integration with a Custom App.
 
 <message type='warning'>
 Server-side integration is no longer supported. 
-This means your applications
-will still be working, 
-but you won't be able to edit their
-configuration.
+This means the applications using server-side actions will still be working, 
+but you won't be able to modify the server-side configuration options such as
+Preliminary Callback URL or Basic Authentication.
+You will be able to deactivate them and change the implementation to a new one.
 </message>
 
 ## Create an OAuth 2.0 Application
@@ -67,7 +67,7 @@ To configure the integration, follow the guidance below for each value.
 |--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| 
 | Client Callback URL | Handles additional callback requests from Box after the primary request with Popup Integrations. If the application specifies a file parameter in the REST method, the preliminary callback URL cannot originate from the client. As a result, a second request must be made from the client to your server so the server can send the necessary interface to the user. |
 | User Experience | Informs that the integration will open in a new window.|
-| New window settings | Determines if the application opens in a new tab. |
+| New Window Settings | Determines if the application opens in a new tab. |
 
 <!-- markdownlint-enable line-length -->
 
@@ -81,9 +81,9 @@ specify the **Parameter name** and add a **Parameter value**.
 Available methods are **Get** and **Post**. 
 
 <message type='warning'>
-**File** method is no longer supported. I you already used this method,
-you cannot edit its values. You can change **File** method to **Get**
-or **Post**, but you cannot undo this action.
+The **File** method is no longer supported. If you already used this method,
+you cannot edit its values. You can change the **File** method to **Get**
+or **Post**, but you can't undo this action.
 </message>
 
 For example: **Get - `userid` - `#user_id#`**.
@@ -103,11 +103,6 @@ The following parameter values are available.
 | `redirect_to_box_url` | In Popup Integrations, the URL to which requests are sent by the confirmation prompt. Use this URL to redirect users to the All Files page. This parameter closes the popup panel and refreshes the All Files page to reflect any changes performed by the integration. If you do not want to add this parameter to your application, you can specify the entire URL. **Success**: `#redirect_to_box_url#&status=success&message=Your%20action%20was%20successful%2E`.  **Failure**: `#redirect_to_box_url#&status=failure&message=Your%20action%20was%20unsuccessful%2E`|
 
 <!-- markdownlint-enable line-length -->
-
-### Authentication
-
-Switch on the toggle **Enable HTTP Basic Authentication**
-to create a username and password.
 
 ### Integration Status
 

--- a/content/guides/applications/web-app-integrations/configure.md
+++ b/content/guides/applications/web-app-integrations/configure.md
@@ -58,7 +58,6 @@ To configure the integration, follow the guidance below for each value.
 | Field | Description |
 |--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| 
 | Client Callback URL | Handles additional callback requests from Box after the primary request with Popup Integrations. If the application specifies a file parameter in the REST method, the preliminary callback URL cannot originate from the client. As a result, a second request must be made from the client to your server so the server can send the necessary interface to the user. |
-| Preliminary Callback URL | The URL where callback parameters are sent when the user accepts the prompt. In most cases it should be a URL that performs an API call on the application server, but it can be any endpoint configured to accept HTTP requests. |
 | User Experience | Determines whether the integration is a [Popup][pu] or [Server-Side][ssi] Integration. |
 | New window settings | Determines if the application opens in a new tab. |
 

--- a/content/guides/applications/web-app-integrations/index.md
+++ b/content/guides/applications/web-app-integrations/index.md
@@ -11,10 +11,10 @@ alias_paths:
 
 # Web App Integration
 
-Box Platform enables an application to provide features to Box users directly
-within the Box web application. Web App Integrations allow applications to
-become part of the Box user experience by allowing users to share and edit files
-with third-party applications.
+Web App Integrations allow third-party applications to
+become part of the Box user experience by 
+allowing users to use such third-party applications
+when editing or sharing files.
 
 ## Features
 

--- a/content/guides/applications/web-app-integrations/types.md
+++ b/content/guides/applications/web-app-integrations/types.md
@@ -29,13 +29,3 @@ Token, and then use that to make API calls to Box.
   response from the callback URL should include an `X-Frame-Options` header set
   to a random string value.
 </Message>
-
-## Server-side Integration
-
-In a server integration, accepting the confirmation prompt sends a request to
-the final callback URL of the application without providing any extra UI to the
-user.
-
-The integration receives a short-lived authorization code with this request,
-which can be used to connect to the Box APIs, exchange the code for an Access
-Token, and then use that to make API calls to Box.

--- a/content/guides/applications/web-app-integrations/types.md
+++ b/content/guides/applications/web-app-integrations/types.md
@@ -11,7 +11,7 @@ alias_paths: []
 
 # Integrations Types
 
-There are two types of Web App Integrations.
+Currently, Box provides the Popup integration type.
 
 ## Popup Integrations
 


### PR DESCRIPTION
# Description

https://staging.developer.box.com/guides/applications/web-app-integrations/types/ - removed server-side integration section
https://staging.developer.box.com/guides/applications/web-app-integrations/configure/ - removed preliminary callback URL section, updated User Experience section. Removed Authentication section. I also added a note in on top of this page, because the feature behavior can be different for users who had the server-server feature already in place. For the same reason, I adjusted the Callback Parameters section. (I based this on the input from this doc: https://cloud.app.box.com/file/958463673555?s=uwk4jvanbofom2ckvk9q0wcnkc2vxqdy

Fixes DDOC-599 

For changelog entry, see  https://github.com/box/box-developer-changelog/pull/241