### PR TITLE
DDOC-722: Remove obsolete information

### DIFF
--- a/content/guides/embed/ui-elements/browser.md
+++ b/content/guides/embed/ui-elements/browser.md
@@ -14,7 +14,6 @@ alias_paths: []
 Box UI elements are supported in the following browsers.
 
 - Chrome, Firefox, Safari, and Edge (latest 2 versions)
-- Limited support for Internet Explorer 11 (requires a `ES2015/Intl polyfill`)
 - Mobile Chrome and Safari
 
 ## ES2015 `Intl` Polyfill


### PR DESCRIPTION
# Description

Removed obsolete information: internet explorer 11 is no longer supported. 

Fixes DDOC-722
