### PR TITLE
Follow up for DDOC-699

### DIFF
--- a/content/guides/internal-documentation/architecture/0-index.md
+++ b/content/guides/internal-documentation/architecture/0-index.md
@@ -31,12 +31,12 @@ they pull their sources from.
 
 | Sources | Production | Staging | Japan |
 | --- | --- | --- | --- |
-| | `developer.box.com` | `staging.developer.box.com` | `ja.developer.box.com` |
-| OpenAPI | `@box/openapi#main` | `@box/openapi#staging` | |
-| OpenAPI Compiled (EN) | `@box/openapi#en` | `@box/openapi#en-staging` `@boxopenapi#jp` |
-| Microcopy & Guides (EN) | `@box/developer.box.com#main` | `@box/developer.box.com#staging` | |
-| Microcopy & Guides Compiled (EN) | `@box/developer.box.com#en` | `@box/developer.box.com#en-staging` | `@box/developer.box.com#jp` |
-| Gatsby Site | `@box/developer.box.com-framework#main` | `@box/developer.box.com-framework#staging` | `@box/developer.box.com-framework#main` |
+| | `developer.box.com`, `box.dev` | `staging.developer.box.com` | `ja.developer.box.com` | `box.dev` |
+| OpenAPI | `@box/openapi#main` | `@box/openapi#staging` | | |
+| OpenAPI Compiled (EN) | `@box/openapi#en` | `@box/openapi#en-staging` `@boxopenapi#jp` | |
+| Microcopy & Guides (EN) | `@box/developer.box.com#main` | `@box/developer.box.com#staging` | | |
+| Microcopy & Guides Compiled (EN) | `@box/developer.box.com#en` | `@box/developer.box.com#en-staging` | `@box/developer.box.com#jp` | |
+| Gatsby Site | `@box/developer.box.com-framework#main` | `@box/developer.box.com-framework#staging` | `@box/developer.box.com-framework#main` | |
 
 <!-- markdownlint-enable line-length -->
 

--- a/content/guides/internal-documentation/architecture/1-sources.md
+++ b/content/guides/internal-documentation/architecture/1-sources.md
@@ -8,7 +8,7 @@ hide: true
 
 A set of sources, managed by technical publications team (in collaboration
 with the developer relations team) and other teams, is used to 
-build the content for Box developer documentation documentation.
+build the content for Box developer documentation.
 The sources are stored in GitHub repositories.
 
 <ImageFrame center shadow border>
@@ -20,7 +20,7 @@ The sources are stored in GitHub repositories.
 - [Box Platform API] - a set of files that represent the Open API 3.0 
 specification for the Box Platform API. These files describe up-to-date
 contents of the API endpoints. 
-- [developer.box.com] - a set of files that represent the microcopy,
+- [developer.box.com, box.dev] - a set of files that represent the microcopy,
 locale configuration, guides, and pages for the developer documentation
 site.
 - [Framework] - source for the Gatsby templates and importers for the


### PR DESCRIPTION
Follow up for [DDOC-699](https://jira.inside-box.net/browse/DDOC-699): corrected typos, added box.dev to sources.

