### PR TITLE
DDOC-760: Add note about Android SDK EOS

### DIFF
--- a/content/guides/mobile/android/index.md
+++ b/content/guides/mobile/android/index.md
@@ -8,4 +8,11 @@ related_pages:
 The [Box Android SDK][android-sdk] provides native access to the Box API from
 within your Android project.
 
+<Message type='warning'>
+As of May 31, 2023 Android SDK will no longer be supported. You can still use your existing Android SDK applications with no impact, but you won't receive new features, updates, or bug fixes.
+
+If you would like to continue getting the latest and greatest Android features, we recommend using Java SDK to build apps on Android. Refer to [this][android-docs] documentation for more details.
+</Message>
+
 [android-sdk]: https://github.com/box/box-android-sdk 
+[android-docs]: https://github.com/box/box-java-sdk/blob/main/doc/android.md

--- a/content/guides/mobile/android/index.md
+++ b/content/guides/mobile/android/index.md
@@ -9,9 +9,17 @@ The [Box Android SDK][android-sdk] provides native access to the Box API from
 within your Android project.
 
 <Message type='warning'>
-As of May 31, 2023 Android SDK will no longer be supported. You can still use your existing Android SDK applications with no impact, but you won't receive new features, updates, or bug fixes.
+As of May 31, 2023 Android SDK will no
+longer be supported.
+You can still use your
+existing Android SDK applications with no impact,
+but you won't receive new features,
+updates, or bug fixes.
 
-If you would like to continue getting the latest and greatest Android features, we recommend using Java SDK to build apps on Android. Refer to [this][android-docs] documentation for more details.
+If you would like to continue getting
+the latest and greatest Android features, 
+we recommend using Java SDK to build apps on Android.
+Refer to [this][android-docs] documentation for more details.
 </Message>
 
 [android-sdk]: https://github.com/box/box-android-sdk 

--- a/content/guides/mobile/android/install.md
+++ b/content/guides/mobile/android/install.md
@@ -6,9 +6,16 @@ related_pages:
 # Android SDK Installation
 
 <Message type='warning'>
-As of May 31, 2023 Android SDK will no longer be supported. You can still use your existing Android SDK applications with no impact, but you won't receive new features, updates, or bug fixes.
+As of May 31, 2023 Android SDK will
+no longer be supported. You can still
+use your existing Android SDK applications
+with no impact, but you won't receive new features,
+updates, or bug fixes.
 
-If you would like to continue getting the latest and greatest Android features, we recommend using Java SDK to build apps on Android. Refer to [this][android-docs] documentation for more details.
+If you would like to continue
+getting the latest and greatest Android
+features, we recommend using Java SDK to build apps
+on Android. Refer to [this][android-docs] documentation for more details.
 </Message>
 
 The Android SDK may be obtained through several methods:

--- a/content/guides/mobile/android/install.md
+++ b/content/guides/mobile/android/install.md
@@ -5,6 +5,12 @@ related_pages:
 
 # Android SDK Installation
 
+<Message type='warning'>
+As of May 31, 2023 Android SDK will no longer be supported. You can still use your existing Android SDK applications with no impact, but you won't receive new features, updates, or bug fixes.
+
+If you would like to continue getting the latest and greatest Android features, we recommend using Java SDK to build apps on Android. Refer to [this][android-docs] documentation for more details.
+</Message>
+
 The Android SDK may be obtained through several methods:
 
 * Adding as a Maven or Gradle dependency
@@ -50,3 +56,4 @@ Precompiled JARs for the Android SDK may be obtained from the Github project
 
 [android-sdk-github]: https://github.com/box/box-android-sdk/tree/master/box-content-sdk
 [android-sdk-github-releases]: https://github.com/box/box-android-sdk/releases
+[android-docs]: https://github.com/box/box-java-sdk/blob/main/doc/android.md

--- a/content/pages/sdks-and-tools/index.md
+++ b/content/pages/sdks-and-tools/index.md
@@ -28,9 +28,16 @@ receive regular product updates, as well as security updates.
 | [Android Content SDK][androidsdk] | Until May 31, 2023    | Partial |
 
 <Message type='warning'>
-As of May 31, 2023 Android SDK will no longer be supported. You can still use your existing Android SDK applications with no impact, but you won't receive new features, updates, or bug fixes.
+As of May 31, 2023 Android SDK will no
+longer be supported. You can still
+use your existing Android SDK applications
+with no impact, but you won't receive new features,
+updates, or bug fixes.
 
-If you would like to continue getting the latest and greatest Android features, we recommend using Java SDK to build apps on Android. Refer to [this][android-docs] documentation for more details.
+If you would like to continue getting the
+latest and greatest Android features, we
+recommend using Java SDK to build apps on Android.
+Refer to [this][android-docs] documentation for more details.
 </Message>
 
 <Message type='notice'>
@@ -101,7 +108,6 @@ become available for the Box Platform. If you are a Box customer on a premium
 support plan, please contact customer services for any urgent feature requests
 for these tools.
 </Message>
-
 
 [javasdk]: https://github.com/box/box-java-sdk
 [dotnetsdk]: https://github.com/box/box-windows-sdk-v2

--- a/content/pages/sdks-and-tools/index.md
+++ b/content/pages/sdks-and-tools/index.md
@@ -25,10 +25,15 @@ receive regular product updates, as well as security updates.
 | [Node SDK][nodesdk]               | Yes         | Full    |
 | [CLI][cli]                        | Yes         | Full    |
 | [iOS Content SDK][iossdk]         | Yes         | Full    |
-| [Android Content SDK][androidsdk] | Yes         | Partial |
+| [Android Content SDK][androidsdk] | Until May 31, 2023    | Partial |
+
+<Message type='warning'>
+As of May 31, 2023 Android SDK will no longer be supported. You can still use your existing Android SDK applications with no impact, but you won't receive new features, updates, or bug fixes.
+
+If you would like to continue getting the latest and greatest Android features, we recommend using Java SDK to build apps on Android. Refer to [this][android-docs] documentation for more details.
+</Message>
 
 <Message type='notice'>
-
 **Maintained:** Fully maintained projects are actively developed by Box. They
 receive the latest security updates and new features. For support with these
 projects please visit GitHub or [our Platform support forum][forum].
@@ -37,7 +42,6 @@ projects please visit GitHub or [our Platform support forum][forum].
 platform functionality as this becomes available on the Box Platform. Projects
 with partial API parity lack some functionality while we work on bringing
 these projects to full parity.
-
 </Message>
 
 ## Official UI Libraries
@@ -61,14 +65,12 @@ preview files on Box.
 
   <!-- markdownlint-enable line-length -->
 
-  <Message type='notice'>
-
+<Message type='notice' >
 **Maintained:** Fully maintained projects are actively developed by Box. They
 receive the latest security updates and new features.  For support with these
 projects please visit GitHub or [our Platform support
 forum][forum]."
-
-  </Message>
+</Message>
 
 ## Unofficial & Community Tools
 
@@ -86,7 +88,6 @@ members. These tools do not receive regular product updates or security updates.
   <!-- markdownlint-enable line-length -->
 
 <Message type='notice'>
-
 **Maintained:** Projects with limited maintenance are updated by Box in
 collaboration with the community. They receive irregular security updates. If
 you are a Box customer on a premium support plan, please contact customer
@@ -99,8 +100,8 @@ as new features are not automatically rolled out to these projects as they
 become available for the Box Platform. If you are a Box customer on a premium
 support plan, please contact customer services for any urgent feature requests
 for these tools.
-
 </Message>
+
 
 [javasdk]: https://github.com/box/box-java-sdk
 [dotnetsdk]: https://github.com/box/box-windows-sdk-v2
@@ -108,6 +109,7 @@ for these tools.
 [nodesdk]: https://github.com/box/box-node-sdk
 [iossdk]: https://github.com/box/box-ios-sdk
 [androidsdk]: https://github.com/box/box-android-sdk
+[android-docs]: https://github.com/box/box-java-sdk/blob/main/doc/android.md
 [cli]: https://github.com/box/boxcli
 [forum]: https://community.box.com/t5/Platform-and-Development-Forum/bd-p/DeveloperForum
 [browseimg]: ./browse.jpg


### PR DESCRIPTION
# Description

Added a note to the docs about Android SDK EOS so users are aware of the changes to come.

Preview:
https://staging.developer.box.com/guides/mobile/android/
https://staging.developer.box.com/guides/mobile/android/install/
https://staging.developer.box.com/sdks-and-tools/ 

Fixes DDOC-760

