### PR TITLE
DDOC-758: Add a guide for zip archive download

### DIFF
--- a/content/guides/api-calls/permissions-and-errors/common-errors.md
+++ b/content/guides/api-calls/permissions-and-errors/common-errors.md
@@ -141,8 +141,9 @@ for solution to common errors encountered when working with the Box APIs.
 |  |   |
 | **Error**| `user_already_collaborator`  |
 | **Message**  | User is already a collaborator  |
-| **Solution** | The user that you are attempting to collaborate in on an item is already collaborated on that item. This request is not  |
-| |   |
+| **Solution** | The user that you are attempting to collaborate in on an item is already collaborated on that item. This request is not needed.|
+| |  |
+
 <!-- i18n-disable localize-links -->
 <!-- markdownlint-enable line-length -->
 

--- a/content/guides/downloads/folder.md
+++ b/content/guides/downloads/folder.md
@@ -12,11 +12,15 @@ alias_paths:
   - /docs/get-all-files
 ---
 
-# Download All Files in Folder
+# Download All Files in Folder using SDKs
 
 Sometimes an application might want to download all files for a folder. To do so
 with the SDKs and the CLI requires traversing the folder tree, finding every
 file and downloading it accordingly.
+
+<Message type="notice">
+To download a ZIP archive, follow [this](g://downloads/zip-archive) guide.
+</Message>
 
 <!-- markdownlint-disable line-length -->
 

--- a/content/guides/downloads/shared-link.md
+++ b/content/guides/downloads/shared-link.md
@@ -5,6 +5,7 @@ related_endpoints:
 related_guides:
   - downloads/file
   - uploads/direct/file
+  - downloads/zip-archive
 required_guides:
   - shared-links/find-for-item
 related_resources: []
@@ -15,6 +16,11 @@ alias_paths: []
 
 To download the file for a [Shared Link][shared-link], first [determine the
 file][get-file] for the link.
+
+<Message notice>
+You cannot use the shared link to download folders. [Create and download
+the ZIP archive][zip-archive-download] instead.
+</Message>
 
 Once the file ID has been determined, the file can be downloaded by passing the
 `BoxAPI` header to the API.
@@ -28,3 +34,4 @@ Once the file ID has been determined, the file can be downloaded by passing the
 
 [shared-link]: g://shared-links
 [get-file]: g://shared-links/find-for-item
+[zip-archive-download]: g://downloads/zip-archive

--- a/content/guides/downloads/zip-archive.md
+++ b/content/guides/downloads/zip-archive.md
@@ -1,0 +1,67 @@
+---
+rank: 11
+related_endpoints:
+  - get_zip_downloads_id_content
+  - get_zip_downloads_id_status
+  - post_zip_downloads
+related_guides: []
+required_guides: []
+alias_paths: []
+---
+
+<!-- markdownlint-disable line-length -->
+# Download ZIP Archive
+
+To download all files in a folder or an entire folder structure, you have to create and download a ZIP archive.
+
+## Create a ZIP Archive
+
+First, you need to create a ZIP archive containing the files or the folder structure. You can include up to 10,000 file and folder IDs unless you reach the account’s upload limit.
+
+<Samples id="post_zip_downloads" />
+
+The response will look similar to the following:
+
+```json
+{
+"download_url":"https://dl.boxcloud.com/2.0/zip_downloads/25gvaXcIE4QJlinNiw2oHAQ==ZFs3Q2Xpd7pKBz7OyzXNrUaoW3aJxQRN5znAvyM-KpdEEPdWcQDKU-Dl85Ew/content",
+"status_url":"https://api.box.com/2.0/zip_downloads/25gvaXcIE4QJlinNiw2oHAQ==ZFs3Q2Xpd7pKBz7OyzXNrUaoW3aJxQRN5znAvyM-KpdEEPdWcQDKU-Dl85Ew/status",
+"expires_at":"2023-02-28T10:23:54Z",
+"name_conflicts":[]
+}
+```
+
+## Extract the ZIP download ID
+
+To download the ZIP archive, you need the ZIP download ID.
+You can find it in the response you got when you created the archive.
+
+Go to `status_url` and copy the ID located between`zip_downloads` and `content`:
+
+```json
+25gvaXcIE4QJlinNiw2oHAQ==ZFs3Q2Xpd7pKBz7OyzXNrUaoW3aJxQRN5znAvyM-KpdEEPdWcQDKU-Dl85Ew
+```
+
+<Message type='notice'>
+Download URL is valid only for a the time specified in `expires_at` parameter.
+</Message>
+
+## Download files
+ 
+Place the download ID in the file location URL as in the sample below
+to point to the right files.
+
+<Samples id="get_zip_downloads_id_content" />
+
+For downloads that take longer, you can monitor the
+download status using the
+[status endpoint](e://get-zip-downloads-id-status).
+This allows you to inspect the progress of the
+download as well as the number of items that might have been skipped.
+
+<Samples id="get_zip_downloads_id_status" />
+
+<Message notice>
+If you want to use SDKs to download the contents
+of the folder, follow [this](g://downloads/folder) guide.
+</Message>


### PR DESCRIPTION
# Description

Created a guide on how to create and download zip archives.
Fix cURL samples to properly use the --location option (fixed with: https://github.com/box-community/box-curl-samples/pull/14) 
Fix wording for errors.

Fixes DDOC-758, DDOC-789
https://staging.developer.box.com/guides/downloads/zip-archive/

