### PR TITLE
fix: Update BUIE v17 CDN links for manual installation

### DIFF
--- a/content/guides/embed/ui-elements/installation.md
+++ b/content/guides/embed/ui-elements/installation.md
@@ -56,21 +56,21 @@ All the UI elements are also available directly from the Box CDN.
 
 | Element                                              | Version  | File                                                                                                                                                                            |
 | ---------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Content Explorer](g://embed/ui-elements/explorer)   | `16.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/explorer.css`](https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/explorer.css)                              |
-|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/explorer.js`](https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/explorer.js)                      |
-|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/explorer.no.react.js`](https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/explorer.no.react.js) |
-| [Content Open With](g://embed/ui-elements/open-with) | `16.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/openwith.css`](https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/openwith.css)                              |
-|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/openwith.js`](https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/openwith.js)                      |
-|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/openwith.no.react.js`](https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/openwith.no.react.js) |
-| [Content Picker](g://embed/ui-elements/picker)       | `16.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/picker.css`](https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/picker.css)                                  |
-|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/picker.js`](https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/picker.js)                          |
-|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/picker.no.react.js`](https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/picker.no.react.js)     |
-| [Content Sidebar](g://embed/ui-elements/sidebar)     | `16.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/sidebar.css`](https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/sidebar.css)                                |
-|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/sidebar.js`](https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/sidebar.js)                        |
-|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/sidebar.no.react.js`](https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/sidebar.no.react.js)   |
-| [Content Uploader](g://embed/ui-elements/uploader)   | `16.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/uploader.css`](https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/uploader.css)                              |
-|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/uploader.js`](https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/uploader.js)                      |
-|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/uploader.no.react.js`](https://cdn01.boxcdn.net/platform/elements/16.0.0/en-US/uploader.no.react.js) |
+| [Content Explorer](g://embed/ui-elements/explorer)   | `17.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/explorer.css`](https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/explorer.css)                              |
+|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/explorer.js`](https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/explorer.js)                      |
+|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/explorer.no.react.js`](https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/explorer.no.react.js) |
+| [Content Open With](g://embed/ui-elements/open-with) | `17.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/openwith.css`](https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/openwith.css)                              |
+|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/openwith.js`](https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/openwith.js)                      |
+|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/openwith.no.react.js`](https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/openwith.no.react.js) |
+| [Content Picker](g://embed/ui-elements/picker)       | `17.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/picker.css`](https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/picker.css)                                  |
+|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/picker.js`](https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/picker.js)                          |
+|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/picker.no.react.js`](https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/picker.no.react.js)     |
+| [Content Sidebar](g://embed/ui-elements/sidebar)     | `17.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/sidebar.css`](https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/sidebar.css)                                |
+|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/sidebar.js`](https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/sidebar.js)                        |
+|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/sidebar.no.react.js`](https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/sidebar.no.react.js)   |
+| [Content Uploader](g://embed/ui-elements/uploader)   | `17.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/uploader.css`](https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/uploader.css)                              |
+|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/uploader.js`](https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/uploader.js)                      |
+|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/uploader.no.react.js`](https://cdn01.boxcdn.net/platform/elements/17.0.0/en-US/uploader.no.react.js) |
 | [Content Preview](g://embed/ui-elements/preview)     | `2.81.0` | CSS [`https://cdn01.boxcdn.net/platform/preview/2.81.0/en-US/preview.css`](https://cdn01.boxcdn.net/platform/preview/2.81.0/en-US/preview.css)                                  |
 |                                                      |          | JS [`https://cdn01.boxcdn.net/platform/preview/2.81.0/en-US/preview.js`](https://cdn01.boxcdn.net/platform/preview/2.81.0/en-US/preview.js)                                     |
 
@@ -200,7 +200,7 @@ For example, if you self-host using a `box-assets` directory, these URLs must
 be accessible:
 
 - `https://cdn.YOUR_SITE.com/box-assets/2.81.0/en-US/preview.js`
-- `https://cdn.YOUR_SITE.com/box-assets/third-party/text/0.116.0/papaparse.min.js`
+- `https://cdn.YOUR_SITE.com/box-assets/third-party/text/2.65.0/papaparse.min.js`
 - `https://cdn.YOUR_SITE.com/box-assets/third-party/model3d/1.12.0/three.min.js`
 
 ## Authentication


### PR DESCRIPTION
## Description

Updating the version in the CDN links on the installation page for UI Elements to the latest release: https://github.com/box/box-ui-elements/releases/tag/v17.0.0

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch
