### PR TITLE
fix: remove extra forward slash for Box View CTA links

### DIFF
--- a/content/guides/embed/box-view/setup.md
+++ b/content/guides/embed/box-view/setup.md
@@ -23,7 +23,7 @@ content with a user.
 The first step is to create the application and authorize it through your admin
 to begin making API requests to Box.
 
-<CTA to='guide://authentication/app-token/app-token-setup/'>
+<CTA to='guide://authentication/app-token/app-token-setup'>
   Setup and authorize App Token app
 </CTA>
 

--- a/content/guides/embed/box-view/upload-file.md
+++ b/content/guides/embed/box-view/upload-file.md
@@ -23,13 +23,13 @@ the APIs, you need to use the client ID and App Token that are generated
 during [application setup](guide://embed/box-view/setup) to authenticate your
 application.
 
-<CTA to='guide://authentication/app-token/'>
+<CTA to='guide://authentication/app-token'>
   Authenticate your application
 </CTA>
 
 Once an authenticated client has been created, it may be used to upload files
 directly to the App Token application for conversion.
 
-<CTA to='guide://uploads/direct/file/'>
+<CTA to='guide://uploads/direct/file'>
   Upload files to Box
 </CTA>


### PR DESCRIPTION
## Description

There is an extra forward slash for the CTA links on the Box View guides
<img width="358" alt="Screen Shot 2023-06-01 at 12 17 58 PM" src="https://github.com/box/developer.box.com/assets/7311041/207d5897-3fb3-4584-b704-a30a0b9899dc">

Looking at how other CTAs are set up in the repo, they do not have a trailing slash:
https://github.com/box/developer.box.com/blob/43ebf1af948fc9706b212174aca766792c56c712/content/guides/internal-documentation/ui-elements/cta.md?plain=1#L13

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch