### PR TITLE
fix: change 'build-in' to 'built-in'

### DIFF
--- a/content/guides/authentication/app-token/with-sdk.md
+++ b/content/guides/authentication/app-token/with-sdk.md
@@ -13,7 +13,7 @@ alias_paths: []
 
 # App Tokens with SDKs
 
-The official Box SDKs have build-in support for App Token authentication.
+The official Box SDKs have built-in support for App Token authentication.
 
 App Token authentication is designed for working directly with the
 Box API without requiring a user to redirect through Box to authorize your

--- a/content/guides/authentication/jwt/with-sdk.md
+++ b/content/guides/authentication/jwt/with-sdk.md
@@ -15,7 +15,7 @@ alias_paths: []
 
 # JWT with SDKs
 
-The official Box SDKs have build-in support for JWT authentication.
+The official Box SDKs have built-in support for JWT authentication.
 
 This guide will take you through user authentication using JWT with the use
 of the Box SDKs. JWT authentication is designed for working directly with the


### PR DESCRIPTION
# Description

Fixing a small typo in the `[...] with SDKs` markdowns of the authentication guides.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch