### PR TITLE
Add alias for common errors

### DIFF
--- a/content/guides/api-calls/permissions-and-errors/common-errors.md
+++ b/content/guides/api-calls/permissions-and-errors/common-errors.md
@@ -9,6 +9,7 @@ alias_paths:
   - /docs/error-codes
   - /docs/detailed-error-messages
   - /docs
+  - /docs/errors
 notes: |-
   Lazy copy of old docs. Needs rethinking.
 ---


### PR DESCRIPTION
# Description
Added alias so that http://developers.box.com/docs/#errors redirects to https://developer.box.com/guides/api-calls/permissions-and-errors/common-errors/
