### PR TITLE
DDOC-828: Add info on Platform Insights

### DIFF
--- a/content/guides/api-calls/index.md
+++ b/content/guides/api-calls/index.md
@@ -16,7 +16,7 @@ these APIs.
 ## API calls insights
 
 Admins and co-admins can access the Platform Insights
-dashboard that provides information total number
+dashboard that provides information on the total number
 of API calls per application.
 
 See [Platform Insights][insights] and [applications][apps] for details.

--- a/content/guides/api-calls/index.md
+++ b/content/guides/api-calls/index.md
@@ -12,3 +12,14 @@ The Box API is a restful API that attempts to follow common HTTP standards
 where possible. The following guides take a look at some of the useful
 features and common mistakes that a developer can encounter when working with
 these APIs.
+
+## API calls insights
+
+Admins and co-admins can access the Platform Insights
+dashboard that provides information total number
+of API calls per application.
+
+See [Platform Insights][insights] and [applications][apps] for details.
+
+[insights]: https://support.box.com/hc/en-us/articles/20738406915219-Platform-Insights
+[apps]: g://applications

--- a/content/guides/applications/index.md
+++ b/content/guides/applications/index.md
@@ -36,6 +36,28 @@ create.
 
 <!-- markdownlint-enable line-length -->
 
+## App insights
+
+Admins and co-admins can access the Platform Insights
+dashboard that provides a comprehensive
+view of the organization’s platform usage. 
+This includes app-related data, such as:
+
+* The total number of API calls per application.
+* A list of top applications within the enterprise.
+* A list of pending application approvals.
+* A list of applications awaiting enablement.
+
+See [Platform Insights][insights] for details.
+
+<Message type='notice'>
+You need the following permissions to access
+and view Platform Insights:
+  * View settings and apps for your company
+  * Edit settings and apps for your company
+  * Run new reports and access existing reports
+</Message>
+
 [oauth2]: g://authentication/oauth2
 [jwt]: g://authentication/jwt
 [apptoken]: g://authentication/app-token
@@ -44,3 +66,4 @@ create.
 [custom-skills]: g://applications/custom-skills
 [ccg]: g://authentication/client-credentials/
 [laa]: g://applications/limited-access-apps/
+[insights]: https://support.box.com/hc/en-us/articles/20738406915219-Platform-Insights

--- a/content/pages/support/index.md
+++ b/content/pages/support/index.md
@@ -17,7 +17,7 @@ For developer support, please reach out to us via one of our channels:
 - [Twitter][twitter]: For general questions and support.
 - [File a support ticket][support]: For account specific questions and support.
 
-For to keep up to date with community projects and Platform changes, please use
+To keep up to date with community projects and Platform changes, please use
 one of these available channels:
 
 - [Changelog](page://changelog): For API changes, deprecated services, and


### PR DESCRIPTION
# Description

Added information on Platform Insights to guides on Applications and API Calls.
Staging preview:
* https://staging.developer.box.com/guides/applications/
* https://staging.developer.box.com/guides/api-calls/

Warning: The link to product docs may not work at this point, as the doc is hidden before it goes GA.

Fixes DDOC-828. Changelog entry to be added in a separate PR.

