### PR TITLE
Fedramp high updates

### DIFF
--- a/content/guides/security/fedramp-high.md
+++ b/content/guides/security/fedramp-high.md
@@ -11,7 +11,7 @@ alias_paths: []
 
 ## Overview
 
-It is a certification program that allows federal agencies to use cloud 
+FedRAMP is a certification program that allows federal agencies to use cloud 
 providers for increasingly secure/sensitive government or government-adjacent 
 data. 
 
@@ -20,45 +20,46 @@ and High.
 
 The higher the security level the more restrictions are in place.
 
-Box is already certified as [FedRAMP Moderate and High][FedRAMPCert].
+<!-- 
+Box is already certified as [FedRAMP Moderate and High][FedRAMPCert]. -->
 
-## Considerations
+<!-- ## Considerations
 
 In order to be FedRAMP High compliant, your administrator must setup Box in 
 very a very specific way. It is possible that the administrator has further 
 restricted access to Box functionalities.
 
 Consult with your administrator to identify security restrictions in place that 
-might affect the usage of the API.
+might affect the usage of the API. -->
 
-## API usage in FedRAMP High
+<!-- ## API usage in FedRAMP High
 
 For FedRAMP high, Box uses a specific domain, `box-gov.com` and this affects 
-all API's entry points.
+all API's entry points. -->
 
 <!-- markdownlint-disable line-length -->
-|FedRAMP Moderate |FedRAMP High       |
+<!-- |FedRAMP Moderate |FedRAMP High       |
 |-----------------|-------------------|
 |account.box.com  |account.box-gov.com|
 |api.box.com      |api.box-gov.com    |
 |upload.box.com   |upload.box-gov.com |
 |dl.boxcloud.com  |dl-frh.boxcloud.com|
-|realtime.services.box.net|realtime.services.box-gov.com|
+|realtime.services.box.net|realtime.services.box-gov.com| -->
 
 <!-- markdownlint-enable line-length -->
 
-## API Restrictions
+<!-- ## API Restrictions
 
 The following API entry points are not yet available for usage under FedRAMP 
-High configuration.
+High configuration. -->
 
 <!-- markdownlint-disable line-length -->
-|API Entry point |
+<!-- |API Entry point |
 |----------------|
 |/sign_requests|
 |/sign_requests/{sign_request_id}|
 |/sign_requests/{sign_request_id}/cancel|
-|/sign_requests/{sign_request_id}/resend|
+|/sign_requests/{sign_request_id}/resend| -->
 
 <!-- markdownlint-enable line-length -->
 

--- a/content/guides/security/fedramp.md
+++ b/content/guides/security/fedramp.md
@@ -34,8 +34,7 @@ might affect the usage of the API.
 
 ## API usage in FedRAMP
 
-For FedRAMP, Box uses a specific domain, `box-gov.com` and this affects 
-all API's entry points.
+For FedRAMP compliance, you may use the below URLs for API entry points.
 
 <!-- markdownlint-disable line-length -->
 |FedRAMP Moderate |

--- a/content/guides/security/fedramp.md
+++ b/content/guides/security/fedramp.md
@@ -4,7 +4,8 @@ related_endpoints: []
 related_guides: []
 required_guides: []
 related_resources: []
-alias_paths: []
+alias_paths: 
+  - /guides/security/fedramp-high/
 ---
 
 # FedRAMP
@@ -20,31 +21,30 @@ and High.
 
 The higher the security level the more restrictions are in place.
 
-<!-- 
-Box is already certified as [FedRAMP Moderate and High][FedRAMPCert]. -->
+Box is currently certified as [FedRAMP Moderate][FedRAMPCert].
 
-<!-- ## Considerations
+## Considerations
 
-In order to be FedRAMP High compliant, your administrator must setup Box in 
+In order to be FedRAMP compliant, your administrator must setup Box in 
 very a very specific way. It is possible that the administrator has further 
 restricted access to Box functionalities.
 
 Consult with your administrator to identify security restrictions in place that 
-might affect the usage of the API. -->
+might affect the usage of the API.
 
-<!-- ## API usage in FedRAMP High
+## API usage in FedRAMP
 
-For FedRAMP high, Box uses a specific domain, `box-gov.com` and this affects 
-all API's entry points. -->
+For FedRAMP, Box uses a specific domain, `box-gov.com` and this affects 
+all API's entry points.
 
 <!-- markdownlint-disable line-length -->
-<!-- |FedRAMP Moderate |FedRAMP High       |
-|-----------------|-------------------|
-|account.box.com  |account.box-gov.com|
-|api.box.com      |api.box-gov.com    |
-|upload.box.com   |upload.box-gov.com |
-|dl.boxcloud.com  |dl-frh.boxcloud.com|
-|realtime.services.box.net|realtime.services.box-gov.com| -->
+|FedRAMP Moderate |
+|-----------------|
+|account.box.com  |
+|api.box.com      |
+|upload.box.com   |
+|dl.boxcloud.com  |
+|realtime.services.box.net|
 
 <!-- markdownlint-enable line-length -->
 
@@ -138,6 +138,7 @@ and resources without hard-coding the locale.
 [Get a file by ID][endpoint://get-files-id]
 
 [File resource][resource://file]
+
 -->
 
-[FedRAMPCert]:https://marketplace.fedramp.gov/#!/product/box-enterprise-cloud-content-collaboration-platform/versus/box-enterprise-cloud-content-collaboration-platform---high?sort=productName&productNameSearch=box
+[FedRAMPCert]:https://marketplace.fedramp.gov/products/F1212191840


### PR DESCRIPTION
Removing FedRAMP High pieces, due to us not having that certification. This is an emergency change.