### PR TITLE
fix: update BUIE to v20.0.0 and Preview to 2.106.0

### DIFF
--- a/content/guides/embed/ui-elements/installation.md
+++ b/content/guides/embed/ui-elements/installation.md
@@ -43,25 +43,25 @@ All the UI elements are also available directly from the Box CDN.
 
 | Element                                              | Version  | File                                                                                                                                                                            |
 | ---------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Content Explorer](g://embed/ui-elements/explorer)   | `19.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/explorer.css`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/explorer.css)                              |
-|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/explorer.js`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/explorer.js)                      |
-|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/explorer.no.react.js`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/explorer.no.react.js) |
-| [Content Open With](g://embed/ui-elements/open-with) | `19.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/openwith.css`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/openwith.css)                              |
-|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/openwith.js`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/openwith.js)                      |
-|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/openwith.no.react.js`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/openwith.no.react.js) |
-| [Content Picker](g://embed/ui-elements/picker)       | `19.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/picker.css`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/picker.css)                                  |
-|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/picker.js`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/picker.js)                          |
-|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/picker.no.react.js`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/picker.no.react.js)     |
-| [Content Sidebar](g://embed/ui-elements/sidebar)     | `19.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/sidebar.css`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/sidebar.css)                                |
-|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/sidebar.js`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/sidebar.js)                        |
-|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/sidebar.no.react.js`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/sidebar.no.react.js)   |
-| [Content Uploader](g://embed/ui-elements/uploader)   | `19.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/uploader.css`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/uploader.css)                              |
-|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/uploader.js`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/uploader.js)                      |
-|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/uploader.no.react.js`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/uploader.no.react.js) |
-| [Content Preview UI Element](https://github.com/box/box-content-preview)     | `19.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/preview.css`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/preview.css)                                  |
-|                                                      |    `19.0.0`       | JS [`https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/preview.js`](https://cdn01.boxcdn.net/platform/elements/19.0.0/en-US/preview.js)                                     |
-| [Content Preview SDK](g://embed/ui-elements/preview)     | `2.103.0` | CSS [`https://cdn01.boxcdn.net/platform/preview/2.103.0/en-US/preview.css`](https://cdn01.boxcdn.net/platform/preview/2.103.0/en-US/preview.css)                                  |
-|                                                      |       | JS [`https://cdn01.boxcdn.net/platform/preview/2.103.0/en-US/preview.js`](https://cdn01.boxcdn.net/platform/preview/2.103.0/en-US/preview.js)                                     |
+| [Content Explorer](g://embed/ui-elements/explorer)   | `20.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/explorer.css`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/explorer.css)                              |
+|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/explorer.js`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/explorer.js)                      |
+|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/explorer.no.react.js`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/explorer.no.react.js) |
+| [Content Open With](g://embed/ui-elements/open-with) | `20.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/openwith.css`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/openwith.css)                              |
+|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/openwith.js`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/openwith.js)                      |
+|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/openwith.no.react.js`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/openwith.no.react.js) |
+| [Content Picker](g://embed/ui-elements/picker)       | `20.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/picker.css`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/picker.css)                                  |
+|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/picker.js`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/picker.js)                          |
+|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/picker.no.react.js`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/picker.no.react.js)     |
+| [Content Sidebar](g://embed/ui-elements/sidebar)     | `20.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/sidebar.css`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/sidebar.css)                                |
+|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/sidebar.js`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/sidebar.js)                        |
+|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/sidebar.no.react.js`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/sidebar.no.react.js)   |
+| [Content Uploader](g://embed/ui-elements/uploader)   | `20.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/uploader.css`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/uploader.css)                              |
+|                                                      |          | JS with React [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/uploader.js`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/uploader.js)                      |
+|                                                      |          | JS without React [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/uploader.no.react.js`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/uploader.no.react.js) |
+| [Content Preview UI Element](https://github.com/box/box-content-preview)     | `20.0.0` | CSS [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/preview.css`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/preview.css)                                  |
+|                                                      |    `20.0.0`       | JS [`https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/preview.js`](https://cdn01.boxcdn.net/platform/elements/20.0.0/en-US/preview.js)                                     |
+| [Content Preview SDK](g://embed/ui-elements/preview)     | `2.106.0` | CSS [`https://cdn01.boxcdn.net/platform/preview/2.106.0/en-US/preview.css`](https://cdn01.boxcdn.net/platform/preview/2.106.0/en-US/preview.css)                                  |
+|                                                      |       | JS [`https://cdn01.boxcdn.net/platform/preview/2.106.0/en-US/preview.js`](https://cdn01.boxcdn.net/platform/preview/2.106.0/en-US/preview.js)                                     |
 
 Use these links to either download the elements code to your application's
 code, or embed them straight into your page from the CDN.
@@ -149,7 +149,7 @@ steps.
 Either fork the repository and check out the version you want to serve or
 download the specific version as a zip.
 
-- Check out a specific version with `git checkout v2.93.0`.
+- Check out a specific version with `git checkout v2.106.0`.
 - Download a specific version as a zip from the [releases][preview-releases] page.
 
 ### 2. Install dependencies
@@ -164,12 +164,12 @@ yarn install && yarn build:i18n && yarn build:prod
 
 Self-serve everything except for the `dev` folder from the `/dist` folder. You
 must not alter the folder structure and `third-party` needs to be in the same
-folder as `2.93.0`.
+folder as `2.106.0`.
 
 For example, if you self-host using a `box-assets` directory, these URLs must
 be accessible:
 
-- `https://cdn.YOUR_SITE.com/box-assets/2.93.0/en-US/preview.js`
+- `https://cdn.YOUR_SITE.com/box-assets/2.106.0/en-US/preview.js`
 - `https://cdn.YOUR_SITE.com/box-assets/third-party/text/2.65.0/papaparse.min.js`
 - `https://cdn.YOUR_SITE.com/box-assets/third-party/model3d/1.12.0/three.min.js`
 


### PR DESCRIPTION
Updating the versions in the CDN links on the installation page for UI Elements and Preview to the latest releases: https://github.com/box/box-ui-elements/releases/tag/v20.0.0
https://github.com/box/box-content-preview/releases/tag/v2.106.0