### PR TITLE
DDOC-1108: Add AI agent guides

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -307,3 +307,4 @@ Fallbacks
 deprecations
 oasdiff
 FIPS
+OpenAI

--- a/content/guides/box-ai/ask-questions.md
+++ b/content/guides/box-ai/ask-questions.md
@@ -5,6 +5,7 @@ related_endpoints:
 related_guides:
   - box-ai/prerequisites
   - box-ai/generate-text
+  - box-ai/get-agent-default-config
 ---
 
 # Ask questions to Box AI
@@ -48,6 +49,8 @@ Mandatory parameters are in **bold**.
 | **`prompt`**   | The question about your document or content. The prompt's length cannot exceed 10000 characters. | | "What is this document about?" |
 |**`items.id`**  | The Box file ID you want to provide as input. | | `112233445566`|
 | **`items.type`** | The type of the provided input. Currently, it can be a single file or multiple files.  | `file`          | `file`   |
-| `items.content` | The content of the item, often the text representation.  |     |  “An application programming interface (API) is a way for two or more computer programs or components to communicate with each other. It is a type of software interface……”    |
+| `items.content` | The content of the item, often the text representation.  |     |  “An application programming interface (API) is a way for two or more computer programs or components to communicate with each other. It is a type of software interface...”    |
+|`ai_agent` | The AI agent used to override the default agent configuration settings. To get the default settings, use the [`GET 2.0/ai_agent_default` endpoint][agent].| |
 
 [prereq]: g://box-ai/prerequisites
+[agent]: e://get_ai_agent_default

--- a/content/guides/box-ai/ask-questions.md
+++ b/content/guides/box-ai/ask-questions.md
@@ -11,9 +11,9 @@ related_guides:
 # Ask questions to Box AI
 
 <Message type="notice">
-Box AI API is a beta feature, which means the
+Box AI Platform API is currently in beta which means the
 available capabilities may change.
-Box AI API is available to all **Enterprise Plus** customers.
+Box AI Platform API is available to all Enterprise Plus customers.
 
 </Message>
 

--- a/content/guides/box-ai/ask-questions.md
+++ b/content/guides/box-ai/ask-questions.md
@@ -30,12 +30,98 @@ To send a request containing your question,
 use the `POST /2.0/ai/ask` endpoint and
 provide the mandatory parameters.
 
-<Samples id='post_ai_ask' />
+```curl
+curl -i -L POST "https://api.box.com/2.0/ai/ask" \
+     -H "content-type: application/json" \
+     -H "authorization: Bearer <ACCESS_TOKEN>" \
+     -d '{
+         "mode": "single_item_qa",
+         "prompt": "What is the value provided by public APIs based on this document?",
+         "items": [
+        {
+            "type": "file",
+            "id": "9842787262"
+        }
+       ],
+          "ai_agent": {
+            "type": "ai_agent_ask",
+            "long_text": {
+              "model": "openai__gpt_3_5_turbo",
+              "system_message": "You are a helpful travel assistant specialized in budget travel",
+              "prompt_template": "It is `{current_date}`, and I have $8000 and want to spend a week in the Azores. What should I see?",
+              "num_tokens_for_completion": 8400,
+              "llm_endpoint_params": {
+                "type": "openai_params",
+                "temperature": 0.0,
+                "top_p": 1.0,
+                "frequency_penalty": 1.5,
+                "presence_penalty": 1.5,
+                "stop": "<|im_end|>"
+              },
+              "embeddings": {
+                "model": "openai__text_embedding_ada_002",
+                "strategy": {
+                  "id": "basic",
+                  "num_tokens_per_chunk": 8400
+                }
+              }
+            },
+            "basic_text": {
+              "model": ""openai__gpt_3_5_turbo"",
+              "system_message": "You are a helpful travel assistant specialized in budget travel",
+              "prompt_template": "It is `{current_date}`, and I have $8000 and want to spend a week in the Azores. What should I see?",
+              "num_tokens_for_completion": 8400,
+              "llm_endpoint_params": {
+                "type": "openai_params",
+                "temperature": 0.0,
+                "top_p": 1.0,
+                "frequency_penalty": 1.5,
+                "presence_penalty": 1.5,
+                "stop": "<|im_end|>"
+              }
+            },
+              "long_text_multi": {
+                "model": "openai__gpt_3_5_turbo",
+                "system_message": "You are a helpful travel assistant specialized in budget travel",
+                "prompt_template": "It is `{current_date}`, and I have $8000 and want to spend a week in the Azores. What should I see?",
+                "num_tokens_for_completion": 8400,
+                "llm_endpoint_params": {
+                  "type": "openai_params",
+                  "temperature": 0.0,
+                  "top_p": 1.0,
+                  "frequency_penalty": 1.5,
+                  "presence_penalty": 1.5,
+                  "stop": "<|im_end|>"
+                },
+                "embeddings": {
+                  "model": "openai__text_embedding_ada_002",
+                  "strategy": {
+                    "id": "basic",
+                    "num_tokens_per_chunk": 8400
+                  }
+                }
+              },
+              "basic_text_multi": {
+                "model": ""openai__gpt_3_5_turbo"",
+                "system_message": "You are a helpful travel assistant specialized in budget travel",
+                "prompt_template": "It is `{current_date}`, and I have $8000 and want to spend a week in the Azores. What should I see?",
+                "num_tokens_for_completion": 8400,
+                  "llm_endpoint_params": {
+                    "type": "openai_params",
+                    "temperature": 0.0,
+                    "top_p": 1.0,
+                    "frequency_penalty": 1.5,
+                    "presence_penalty": 1.5,
+                    "stop": "<|im_end|>"
+                  }
+        }
+      }'
+```
 
 ### Authentication
 
 Make sure you have generated the developer token
-to authorize your app. See [Getting Started with Box AI][prereq]
+to authorize your app. See [prerequisites for using Box A][prereq]
 for details.
 
 ### Parameters
@@ -46,11 +132,13 @@ Mandatory parameters are in **bold**.
 | Parameter    |Description                                                                                             | Available values                               | Example                     |
 | ------------ | ------ | ----------- | --- |
 | **`mode`** | The type of request. It can be a question about a single file or a set of files. For a single file, Box AI API supports up to 1MB of text representation. If the file size exceeds 1MB, the first 1MB of text representation will be processed. If you want to list multiple files, the limit is 25 files. If you set `mode` to `single_item_qa`, the `items` array can list only one element.| `single_item_qa`, `multiple_item_qa` | `single_item_qa`   |
-| **`prompt`**   | The question about your document or content. The prompt's length cannot exceed 10000 characters. | | "What is this document about?" |
+| **`prompt`**   | The question about your document or content. The prompt's length cannot exceed 10000 characters. | | `What is this document about?` |
 |**`items.id`**  | The Box file ID you want to provide as input. | | `112233445566`|
 | **`items.type`** | The type of the provided input. Currently, it can be a single file or multiple files.  | `file`          | `file`   |
-| `items.content` | The content of the item, often the text representation.  |     |  “An application programming interface (API) is a way for two or more computer programs or components to communicate with each other. It is a type of software interface...”    |
-|`ai_agent` | The AI agent used to override the default agent configuration settings. To get the default settings, use the [`GET 2.0/ai_agent_default` endpoint][agent].| |
+| `items.content` | The content of the item, often the text representation.  |     |  `An application programming interface (API) is a way for two or more computer programs or components to communicate with each other. It is a type of software interface...`    |
+|`ai_agent` | The AI agent used to override the default agent configuration. You can use this parameter replace the default LLM with a custom one using the [`model`][model-param] parameter for shorter and longer texts, tweak the base [`prompt`][prompt-param] to allow for a more customized user experience, or change an LLM parameter, such as `temperature`, to make the results more or less creative. Before you use the `ai_agent` parameter, you can get the default configuration using the [`GET 2.0/ai_agent_default`][agent] request.|||
 
 [prereq]: g://box-ai/prerequisites
 [agent]: e://get_ai_agent_default
+[model-param]: r://ai_agent_ask#param_basic_text_model
+[prompt-param]: e://ai_agent_ask#param_basic_text_prompt_template

--- a/content/guides/box-ai/ask-questions.md
+++ b/content/guides/box-ai/ask-questions.md
@@ -121,7 +121,7 @@ curl -i -L POST "https://api.box.com/2.0/ai/ask" \
 ### Authentication
 
 Make sure you have generated the developer token
-to authorize your app. See [prerequisites for using Box A][prereq]
+to authorize your app. See [prerequisites for using Box AI][prereq]
 for details.
 
 ### Parameters

--- a/content/guides/box-ai/generate-text.md
+++ b/content/guides/box-ai/generate-text.md
@@ -5,6 +5,7 @@ related_endpoints:
 related_guides:
   - box-ai/prerequisites
   - box-ai/ask-questions
+  - box-ai/get-agent-default-config
 ---
 # Generate text with Box AI
 
@@ -49,5 +50,7 @@ To make a call, you must pass the following parameters. Mandatory parameters are
 | `dialogue_history.prompt` | The prompt previously provided by the client and answered by the Large Language Model (LLM).  | "Make my email about public APIs sound more professional" |
 | `dialogue_history.answer` | The answer previously provided by the LLM. |   "Here is a draft of your professional email about public APIs." |
 | `dialogue_history.created_at` | The ISO date formatted timestamp of when the previous answer to the prompt was created.   | `2012-12-12T10:53:43-08:00` |
+|`ai_agent` | The AI agent used to override the default agent configuration. To get the default settings, use the [`GET 2.0/ai_agent_default` endpoint][agent].| | 
 
 [prereq]: g://box-ai/prerequisites
+[agent]: e://get_ai_agent_default

--- a/content/guides/box-ai/generate-text.md
+++ b/content/guides/box-ai/generate-text.md
@@ -10,9 +10,9 @@ related_guides:
 # Generate text with Box AI
 
 <Message type="notice">
-Box AI API is a beta feature which means the
+Box AI Platform API is currently in beta which means the
 available capabilities may change.
-Box AI API is available to all Enterprise Plus customers.
+Box AI Platform API is available to all Enterprise Plus customers.
 
 </Message>
 

--- a/content/guides/box-ai/generate-text.md
+++ b/content/guides/box-ai/generate-text.md
@@ -29,10 +29,61 @@ based on provided content.
 To send a request, use the
 `POST /2.0/ai/text_gen` endpoint.
 
-<Samples id='post_ai_text_gen' />
+```curl
+curl -i -L POST "https://api.box.com/2.0/ai/text_gen" \
+     -H "content-type: application/json" \
+     -H "authorization: Bearer <ACCESS_TOKEN>" \
+     -d '{
+          "prompt": "Write a social media post about protein powder.",
+          "items": [
+         {
+            "id": "12345678",
+            "type": "file",
+            "content": "More information about protein powders"
+        },
+        ],
+          "dialogue_history": [
+            {
+                "prompt": "Make my email about public APIs sound more professional",
+                "answer": "Here is the first draft of your professional email about public APIs",
+                "created_at": "2013-12-12T10:53:43-08:00"
+            },
+            {
+                "prompt": "Can you add some more information?",
+                "answer": "Public API schemas provide necessary information to integrate with APIs...",
+                "created_at": "2013-12-12T11:20:43-08:00"
+            }
+        ],
+          "ai_agent": {
+            "type": "ai_agent_text_gen",
+            "basic_gen": {
+              "model": "openai__gpt_3_5_turbo",
+              "system_message": "You are a helpful travel assistant specialized in budget travel",
+              "prompt_template": "It is `{current_date}`, and I have $8000 and want to spend a week in Azores. What should I see?",
+              "num_tokens_for_completion": 8400,
+              "llm_endpoint_params": {
+                "type": "openai_params",
+                "temperature": 2.0,
+                "top_p": 1.0,
+                "frequency_penalty": 1.5,
+                "presence_penalty": 1.5,
+                "stop": "<|im_end|>"
+              },
+              "embeddings": {
+                "model": " openai__text_embedding_ada_002",
+                "strategy": {
+                  "id": "basic",
+                  "num_tokens_per_chunk": 64
+                }
+              },
+              "content_template": "---{content}---"
+           }
+        }
+     }'
+```
 
 Make sure you have generated the developer token
-to authorize your app. See [Prerequisites for Box AI][prereq]
+to authorize your app. See [prerequisites for using Box AI][prereq]
 for details.
 
 ### Parameters
@@ -46,11 +97,13 @@ To make a call, you must pass the following parameters. Mandatory parameters are
 |**`prompt`**| The request for Box AI to generate or refine the text. The prompt's length cannot exceed 10000 characters.|Create a meeting agenda for a weekly sales meeting.|
 |**`items.id`**|Box file ID of the document. |`1233039227512`|
 |**`items.type`**|The type of the supplied input. | `file`|
-| `items.content` | The content of the item, often the text representation.  |     This article is about Box AI.    |
-| `dialogue_history.prompt` | The prompt previously provided by the client and answered by the Large Language Model (LLM).  | "Make my email about public APIs sound more professional" |
-| `dialogue_history.answer` | The answer previously provided by the LLM. |   "Here is a draft of your professional email about public APIs." |
+| `items.content` | The content of the item, often the text representation.  |    `This article is about Box AI`.    |
+| `dialogue_history.prompt` | The prompt previously provided by the client and answered by the Large Language Model (LLM).  | `Make my email about public APIs sound more professional` |
+| `dialogue_history.answer` | The answer previously provided by the LLM. |   `Here is a draft of your professional email about public APIs.` |
 | `dialogue_history.created_at` | The ISO date formatted timestamp of when the previous answer to the prompt was created.   | `2012-12-12T10:53:43-08:00` |
-|`ai_agent` | The AI agent used to override the default agent configuration. To get the default settings, use the [`GET 2.0/ai_agent_default` endpoint][agent].| | 
+|`ai_agent` | The AI agent used to override the default agent configuration. This parameter allows you to, for example, replace the default LLM with a custom one using the [`model`][model-param] parameter, tweak the base [`prompt`][prompt-param] to allow for a more customized user experience, or change an LLM parameter, such as `temperature`, to make the results more or less creative. Before using the `ai_agent` parameter, you can get the default configuration using the [`GET 2.0/ai_agent_default`][agent] request.| | 
 
 [prereq]: g://box-ai/prerequisites
 [agent]: e://get_ai_agent_default
+[model-param]: r://ai_agent_text_gen#param_basic_gen_model
+[prompt-param]: r://ai_agent_text_gen#param_basic_gen_prompt_template

--- a/content/guides/box-ai/get-agent-default-config.md
+++ b/content/guides/box-ai/get-agent-default-config.md
@@ -19,7 +19,13 @@ Box AI API is available to all Enterprise Plus customers.
 </Message>
 
 The `GET /2.0/ai_agent_default` endpoint allows you to fetch the default configuration for AI services. 
-You can then override this configuration using the `ai_agent` parameter available in the `POST /2.0/ai/ask` and `POST /2.0/ai/text_gen` endpoints to [ask questions][ask] or [generate text][text-gen].
+Once you get the configuration details, you can override them using the `ai_agent` parameter available in the [`POST /2.0/ai/ask`][ask] and [`POST /2.0/ai/text_gen`][text-gen] requests.
+
+Override examples include:
+
+* Replacing the default LLM with a custom one based on your organization's needs.
+* Tweaking the base prompt to allow a more customized user experience.
+* Changing a parameter, such as `temperature`, to make the results more or less creative.
 
 ## Send a request
 
@@ -29,7 +35,7 @@ To send a request, use the
 <Samples id='get_ai_agent_default' />
 
 Make sure you have generated the developer token
-to authorize your app. See [Prerequisites for Box AI][prereq]
+to authorize your app. See [prerequisites for using Box AI][prereq]
 for details.
 
 ### Parameters
@@ -39,10 +45,10 @@ To make a call, you must pass the following parameters. Mandatory parameters are
 | Parameter| Description| Example|
 |--------|--------|-------|
 |`language`| The language code the agent configuration is returned for. If the language is not supported, the default configuration is returned. | `ja-JP`| 
-|**`mode`**|The mode used to filter the agent configuration. The value can be `ask` or `text_gen` |`ask`|
+|**`mode`**|The mode used to filter the agent configuration. The value can be `ask` or `text_gen`. |`ask`|
 |`model`|The model you want to get the configuration for. To make sure your chosen model is supported, see the [list of models][models].| `openai__gpt_3_5_turbo`|
 
 [prereq]: g://box-ai/prerequisites
-[ask]: g://box-ai/ask-questions
-[text-gen]: g://box-ai/generate-text
+[ask]: e://post_ai_ask#param_ai_agent
+[text-gen]: e://post_ai_text_gen#param_ai_agent
 [models]: g://box-ai/supported-models

--- a/content/guides/box-ai/get-agent-default-config.md
+++ b/content/guides/box-ai/get-agent-default-config.md
@@ -7,14 +7,15 @@ related_endpoints:
 related_guides:
   - box-ai/prerequisites
   - box-ai/ask-questions
+  - box-ai/generate-text
 ---
 
 # Get AI agent default configuration
 
 <Message type="notice">
-Box AI API is a beta feature which means the
+Box AI Platform API is currently in beta which means the
 available capabilities may change.
-Box AI API is available to all Enterprise Plus customers.
+Box AI Platform API is available to all Enterprise Plus customers.
 
 </Message>
 

--- a/content/guides/box-ai/get-agent-default-config.md
+++ b/content/guides/box-ai/get-agent-default-config.md
@@ -1,0 +1,48 @@
+---
+rank: 7
+related_endpoints:
+  - get_ai_agent_default
+  - post_ai_text_gen
+  - post_ai_ask
+related_guides:
+  - box-ai/prerequisites
+  - box-ai/ask-questions
+---
+
+# Get AI agent default configuration
+
+<Message type="notice">
+Box AI API is a beta feature which means the
+available capabilities may change.
+Box AI API is available to all Enterprise Plus customers.
+
+</Message>
+
+The `GET /2.0/ai_agent_default` endpoint allows you to fetch the default configuration for AI services. 
+You can then override this configuration using the `ai_agent` parameter available in the `POST /2.0/ai/ask` and `POST /2.0/ai/text_gen` endpoints to [ask questions][ask] or [generate text][text-gen].
+
+## Send a request
+
+To send a request, use the
+`GET /2.0/ai/text_gen` endpoint.
+
+<Samples id='get_ai_agent_default'/>
+
+Make sure you have generated the developer token
+to authorize your app. See [Prerequisites for Box AI][prereq]
+for details.
+
+### Parameters
+
+To make a call, you must pass the following parameters. Mandatory parameters are in **bold**.
+
+| Parameter| Description| Example|
+|--------|--------|-------|
+|`language`| The language code the agent configuration is returned for. If the language is not supported, the default configuration is returned. | `ja-JP`| 
+|**`mode`**|The mode used to filter the agent configuration. The value can be `ask` or `text_gen` |`ask`|
+|`model`|The model you want to get the configuration for. To make sure your chosen model is supported, see the [list of models][models].| `openai__gpt_3_5_turbo`|
+
+[prereq]: g://box-ai/prerequisites
+[ask]: g://box-ai/ask-questions
+[text-gen]: g://box-ai/generate-text
+[models]: g://box-ai/supported-models

--- a/content/guides/box-ai/get-agent-default-config.md
+++ b/content/guides/box-ai/get-agent-default-config.md
@@ -24,9 +24,9 @@ You can then override this configuration using the `ai_agent` parameter availabl
 ## Send a request
 
 To send a request, use the
-`GET /2.0/ai/text_gen` endpoint.
+`GET /2.0/ai_agent_default` endpoint.
 
-<Samples id='get_ai_agent_default'/>
+<Samples id='get_ai_agent_default' />
 
 Make sure you have generated the developer token
 to authorize your app. See [Prerequisites for Box AI][prereq]

--- a/content/guides/box-ai/index.md
+++ b/content/guides/box-ai/index.md
@@ -37,7 +37,7 @@ or generate text you can use in your documents.
 You can also use [Box AI for UI Elements][boxaielement]
 to embed Box AI functionality in your apps.
 
-### Ask questions to AI
+### Ask questions to Box AI
 
 You can use Box AI API to ask questions about
 the content, for example, while working
@@ -54,7 +54,7 @@ to see an example of how users can interact
 with Box AI while
 working with their documents.
 
-### Generate text with AI
+### Generate text with Box AI
 
 You can use Box AI API to generate text
 from scratch, from existing text within a Box Note, or

--- a/content/guides/box-ai/index.md
+++ b/content/guides/box-ai/index.md
@@ -12,9 +12,9 @@ related_guides:
 # Box AI
 
 <Message type="notice">
-Box AI API is a beta feature, which means the
+Box AI Platform API is currently in beta which means the
 available capabilities may change.
-Box AI API is available to all **Enterprise Plus** customers.
+Box AI Platform API is available to all Enterprise Plus customers.
 </Message>
 
 Box AI API allows you to use Box AI

--- a/content/guides/box-ai/index.md
+++ b/content/guides/box-ai/index.md
@@ -37,7 +37,7 @@ or generate text you can use in your documents.
 You can also use [Box AI for UI Elements][boxaielement]
 to embed Box AI functionality in your apps.
 
-### Asking questions
+### Ask questions to AI
 
 You can use Box AI API to ask questions about
 the content, for example, while working
@@ -54,7 +54,7 @@ to see an example of how users can interact
 with Box AI while
 working with their documents.
 
-### Generating text
+### Generate text with AI
 
 You can use Box AI API to generate text
 from scratch, from existing text within a Box Note, or
@@ -69,6 +69,12 @@ and refine the already existing note content.
 For details, see [Box AI for Notes][boxainotes].
 
 ![box ai in notes](./images/box-ai-in-notes.png)
+
+## Configuration overrides
+
+You can use the `ai_agent` parameter available in the [`POST /2.0/ai/ask`][ask] and [`POST /2.0/ai/text_gen`][text-gen] requests to override the default agent configuration and introduce your own custom settings.
+
+For details, see [AI agent default configuration](agent-default).
 
 ### Box AI for UI Elements
 
@@ -103,16 +109,19 @@ better results for this language.
 
 [User Activity Reports][uar] provide an overview of the
 actions the users are taking in Box. Box Admins
-use this report to view the actions made by their
+use this report to view the actions taken by their
 users within a given time period, and this
 includes interactions with Box AI. The report
-contains the following action types Box admins can
+contains the following action types that Box admins can
 select to get details for Box AI:
 
-- `AI query`: User queried Box AI and received a response.
-- `Failed AI query`: User queried Box AI but did not receive a response.
+- `AI query`: The user queried Box AI and received a response.
+- `Failed AI query`: The user queried Box AI but did not receive a response.
 
 [boxainotes]: https://support.box.com/hc/en-us/articles/22198577315347-Box-AI-for-Notes
 [boxaidocs]: https://support.box.com/hc/en-us/articles/22158484213267-Box-AI-for-Documents
 [boxaielement]: g://embed/ui-elements/preview#box-ai-ui-element
 [uar]: https://support.box.com/hc/en-us/articles/4415012490387-User-Activity-Report
+[agent-default]: g://box-ai/get-agent-default-config
+[ask]: e://post_ai_ask#param_ai_agent
+[text-gen]: e://post_ai_text_gen#param_ai_agent

--- a/content/guides/box-ai/prerequisites.md
+++ b/content/guides/box-ai/prerequisites.md
@@ -4,6 +4,7 @@ related_guides:
   - authentication/tokens/developer-tokens/
   - box-ai/ask-questions
   - box-ai/generate-text
+  - box-ai/get-agent-default-config
 ---
 
 # Getting started with Box AI

--- a/content/guides/box-ai/prerequisites.md
+++ b/content/guides/box-ai/prerequisites.md
@@ -10,9 +10,9 @@ related_guides:
 # Getting started with Box AI
 
 <Message type="notice">
-Box AI API is a beta feature, which means the
+Box AI Platform API is currently in beta which means the
 available capabilities may change.
-Box AI API is available to all **Enterprise Plus** customers.
+Box AI Platform API is available to all Enterprise Plus customers.
 </Message>
 
 To implement Box AI API in your solutions, you need

--- a/content/guides/box-ai/supported-models.md
+++ b/content/guides/box-ai/supported-models.md
@@ -8,15 +8,21 @@ related_guides:
 
 # Supported AI models
 
+<Message type="notice">
+Box AI Platform API is currently in beta which means the
+available capabilities may change.
+Box AI Platform API is available to all Enterprise Plus customers.
+</Message>
+
 The table list the supported AI models you can use to:
 
-* get the [default AI agent configuration][agent],
-* override the AI agent configuration used in [`POST 2.0/ai/ask`][ask] and [`POST 2.0/ai/text_gen`][text-gen] endpoints.
+  * get the [default AI agent configuration][agent],
+  * override the AI agent configuration used in [`POST 2.0/ai/ask`][ask] and [`POST 2.0/ai/text_gen`][text-gen] endpoints.
 
 <Message type='notice'>
-The list is subject to changes depending on the model availability.
-**Preview** means you can use the model, but its full availability
-is not guaranteed.
+The list may change depending on the model availability.
+**Preview** means you can use the model, but the access to all features
+may be limited.
 </Message>
 
 |Provider | Family | Model | Availability|

--- a/content/guides/box-ai/supported-models.md
+++ b/content/guides/box-ai/supported-models.md
@@ -1,0 +1,36 @@
+---
+rank: 8
+related_guides:
+  - box-ai/ask-questions
+  - box-ai/generate-text
+  - box-ai/get-agent-default-config
+---
+
+# Supported AI models
+
+The table list the supported AI models you can use to:
+
+* get the [default AI agent configuration][agent],
+* override the AI agent configuration used in [`POST 2.0/ai/ask`][ask] and [`POST 2.0/ai/text_gen`][text-gen] endpoints.
+
+<Message type='notice'>
+The list is subject to changes depending on the model availability.
+**Preview** means you can use the model, but its full availability
+is not guaranteed.
+</Message>
+
+|Provider | Family | Model | Availability|
+|---------------| -------|-------| ------------|
+|OpenAI         | GPT| `gpt-3.5-turbo`          | available|
+|Microsoft Azure| GPT| `gpt-3.5-turbo`          | available|
+|GCP Vertex| Gecko   | `textembedding-gecko`    | available|
+|GCP Vertex |Gecko| `textembedding-gecko@002`| available|
+|GCP Vertex|Gecko| `textembedding-gecko@003`| available|
+|GCP Vertex| Gemini  | `gemini 1.0 pro` | preview| 
+|GCP Vertex|Gemini|`gemini 1.5 flash`| preview|
+|GCP Vertex|PaLM| `text-unicorn`| available|
+|GCP Vertex |PaLM|`text-bison`| available| 
+
+[ask]: e://post_ai_ask
+[text-gen]: e://post_ai_text_gen
+[agent]: e://get_ai_agent_default

--- a/content/guides/representations/supported-file-types.md
+++ b/content/guides/representations/supported-file-types.md
@@ -14,173 +14,194 @@ alias_paths: []
 
 The following file types are supported by the representation API.
 
-## Documents
+## Audio
+
+| File Type  | PDF Support? | Thumbnails? | Text? |
+| ---------- | ------------ | ----------- | ----------- |
+| `.aac` | No | Yes | No |
+| `.aif` | No | Yes | No |
+| `.aifc` | No | Yes | No |
+| `.aiff` | No | Yes | No |
+| `.amr` | No | Yes | No |
+| `.au` | No | Yes | No |
+| `.flac` | No | Yes | No |
+| `.m4a` | No | Yes | No |
+| `.mp3` | No | Yes | No |
+| `.ogg` | No | Yes | No |
+| `.ra` | No | Yes | No |
+| `.wav` | No | Yes | No |
+| `.wma` | No | Yes | No |
+
+## CAD
+
+| File Type  | PDF Support? | Thumbnails? | Text? |
+| --- | --- | --- | --- |
+| `.3ds` | No | No | No |
+| `.box3d` | No | No | No |
+| `.dae` | No | No | No |
+| `.dwg` | No | No | No |
+| `.dxf` | No | No | No |
+| `.fbx` | No | No | No |
+| `.mtl` | No | No | No |
+| `.obj` |  No | No | No |
+| `.ply` | No | No | No |
+| `.stl` | No | No | No |
+
+## Document
 
 | File Type  | PDF Support? | Thumbnails? | Text? |
 | ---------- | ------------ | ----------- | ----- |
-| `.doc`     | Yes          | Yes         | Yes   |
-| `.docx`    | Yes          | Yes         | Yes   |
-| `.gdoc`    | Yes          | Yes         | Yes   |
-| `.gsheet`  | Yes          | Yes         | Yes   |
-| `.numbers` | Yes          | Yes         | Yes   |
-| `.ods`     | Yes          | Yes         | Yes   |
-| `.odt`     | Yes          | Yes         | Yes   |
-| `.pages`   | Yes          | Yes         | Yes   |
-| `.pdf`     | Yes          | Yes         | Yes   |
-| `.rtf`     | Yes          | Yes         | Yes   |
-| `.wpd`     | Yes          | Yes         | Yes   |
-| `.xls`     | Yes          | Yes         | Yes   |
-| `.xlsm`    | Yes          | Yes         | Yes   |
-| `.xlsx`    | Yes          | Yes         | Yes   |
+| `.as` | Yes | Yes | Yes |
+| `.as3` | Yes | Yes | Yes |
+| `.asm` | Yes | Yes | Yes |
+| `.bat` | Yes | Yes | Yes |
+| `.boxnote` | Yes | Yes | Yes |
+| `.c` | Yes | Yes | Yes |
+| `.cc` | Yes | Yes | Yes |
+| `.cmake` | Yes | Yes | Yes |
+| `.cpp` | Yes | Yes | Yes |
+| `.cs` | Yes | Yes | Yes |
+| `.css` | Yes | Yes | Yes |
+| `.cxx` | Yes | Yes | Yes |
+| `.diff` | Yes | Yes | Yes |
+| `.doc` | Yes | Yes | Yes |
+| `.docx` | Yes | Yes | Yes |
+| `.eml` | Yes | Yes | Yes |
+| `.erb` | Yes | Yes | Yes |
+| `.groovy`| Yes | Yes | Yes |
+|  `.h` | Yes | Yes | Yes |
+| `.haml` | Yes | Yes | Yes |
+| `.hh` | Yes | Yes | Yes |
+| `.hpp` | Yes | Yes | Yes |
+| `.htm` | Yes | Yes | Yes |
+| `.html` | Yes | Yes | Yes |
+| `.java` | Yes | Yes | Yes |
+| `.js` | Yes | Yes | Yes |
+| `.json` | Yes | Yes | Yes |
+| `.jww` | Yes | Yes | Yes |
+| `.less` | Yes | Yes | Yes |
+| `.log` | Yes | Yes | Yes |
+| `.m` | Yes | Yes | Yes |
+| `.make` | Yes | Yes | Yes |
+| `.md` | Yes | Yes | Yes |
+| `.ml` | Yes | Yes | Yes |
+| `.msg` | Yes | Yes | Yes |
+| `.olk14Message` | Yes | Yes | Yes |
+| `.pdf` | Yes | Yes | Yes |
+| `.php` | Yes | Yes | Yes |
+| `.pl` | Yes | Yes | Yes |
+| `.properties` | Yes | Yes | Yes |
+| `.py` | Yes | Yes | Yes |
+| `.rb` | Yes | Yes | Yes |
+| `.rst` | Yes | Yes | Yes |
+| `.sass` | Yes | Yes | Yes |
+| `.scala` | Yes | Yes | Yes |
+| `.scm` | Yes | Yes | Yes |
+| `.script` | Yes | Yes | Yes |
+| `.sh` | Yes | Yes | Yes |
+| `.sml` | Yes | Yes | Yes |
+| `.sql` | Yes | Yes | Yes |
+| `.vb` | Yes | Yes | Yes |
+| `.vi` | Yes | Yes | Yes |
+| `.vim` | Yes | Yes | Yes |
+| `.wpd` | Yes | Yes | Yes |
+| `.xhtml` | Yes | Yes | Yes |
+| `.xml` | Yes | Yes | Yes |
+| `.xsd` | Yes | Yes | Yes |
+| `.xsl` | Yes | Yes | Yes |
+| `.xbd` | Yes | Yes | Yes |
+| `.xdw` | Yes | Yes | Yes |
+| `.pyc` | Yes | Yes | Yes |
 
-## Text-Based Files
+## Drawing
 
-| File Type     | PDF Support? | Thumbnails? | Text? |
-| ------------- | ------------ | ----------- | ----- |
-| `.as`         | Yes          | Yes         | Yes   |
-| `.as3`        | Yes          | Yes         | Yes   |
-| `.asm`        | Yes          | Yes         | Yes   |
-| `.bat`        | Yes          | Yes         | Yes   |
-| `.c`          | Yes          | Yes         | Yes   |
-| `.cc`         | Yes          | Yes         | Yes   |
-| `.cmake`      | Yes          | Yes         | Yes   |
-| `.cpp`        | Yes          | Yes         | Yes   |
-| `.cs`         | Yes          | Yes         | Yes   |
-| `.css`        | Yes          | Yes         | Yes   |
-| `.csv`        | Yes          | Yes         | Yes   |
-| `.cxx`        | Yes          | Yes         | Yes   |
-| `.diff`       | Yes          | Yes         | Yes   |
-| `.erb`        | Yes          | Yes         | Yes   |
-| `.groovy`     | Yes          | Yes         | Yes   |
-| `.h`          | Yes          | Yes         | Yes   |
-| `.haml`       | Yes          | Yes         | Yes   |
-| `.hh`         | Yes          | Yes         | Yes   |
-| `.htm`        | Yes          | Yes         | Yes   |
-| `.html`       | Yes          | Yes         | Yes   |
-| `.java`       | Yes          | Yes         | Yes   |
-| `.js`         | Yes          | Yes         | Yes   |
-| `.json`       | Yes          | Yes         | Yes   |
-| `.less`       | Yes          | Yes         | Yes   |
-| `.log`        | Yes          | Yes         | Yes   |
-| `.m`          | Yes          | Yes         | Yes   |
-| `.make`       | Yes          | Yes         | Yes   |
-| `.md`         | Yes          | Yes         | Yes   |
-| `.ml`         | Yes          | Yes         | Yes   |
-| `.mm`         | Yes          | Yes         | Yes   |
-| `.msg`        | Yes          | Yes         | Yes   |
-| `.php`        | Yes          | Yes         | Yes   |
-| `.pl`         | Yes          | Yes         | Yes   |
-| `.properties` | Yes          | Yes         | Yes   |
-| `.py`         | Yes          | Yes         | Yes   |
-| `.rb`         | Yes          | Yes         | Yes   |
-| `.rst`        | Yes          | Yes         | Yes   |
-| `.sass`       | Yes          | Yes         | Yes   |
-| `.scala`      | Yes          | Yes         | Yes   |
-| `.scm`        | Yes          | Yes         | Yes   |
-| `.script`     | Yes          | Yes         | Yes   |
-| `.sh`         | Yes          | Yes         | Yes   |
-| `.sml`        | Yes          | Yes         | Yes   |
-| `.sql`        | Yes          | Yes         | Yes   |
-| `.txt`        | Yes          | Yes         | Yes   |
-| `.vi`         | Yes          | Yes         | Yes   |
-| `.vim`        | Yes          | Yes         | Yes   |
-| `.webdoc`     | Yes          | Yes         | Yes   |
-| `.xhtml`      | Yes          | Yes         | Yes   |
-| `.xlsb`       | Yes          | Yes         | Yes   |
-| `.xml`        | Yes          | Yes         | Yes   |
-| `.xsd`        | Yes          | Yes         | Yes   |
-| `.xsl`        | Yes          | Yes         | Yes   |
-| `.yaml`       | Yes          | Yes         | Yes   |
+| File Type | PDF Support? | Thumbnails? | Text? |
+| --- | --- | ---| --- |
+| `.ai` | No | Yes | No |
+| `.boxcanvas` | No | Yes | No |
+| `.indd` | No | Yes | No |
+| `.odg` | No | Yes | No |
+| `.psd` | No | Yes | No |
+| `.svg` | No | Yes | No |
 
-## Presentations
-
-| File Type  | PDF Support? | Thumbnails? | Text? |
-| ---------- | ------------ | ----------- | ----- |
-| `.gslide`  | Yes          | Yes         | Yes   |
-| `.gslides` | Yes          | Yes         | Yes   |
-| `.key`     | Yes          | Yes         | Yes   |
-| `.odp`     | Yes          | Yes         | Yes   |
-| `.ppt`     | Yes          | Yes         | Yes   |
-| `.pptx`    | Yes          | Yes         | Yes   |
-
-## Images
+## Image
 
 | File Type | PDF Support? | Thumbnails? | Text? |
 | --------- | ------------ | ----------- | ----- |
-| `.ai`     | No           | Yes         | No    |
+| `.arw`    | No           | Yes         | No    |
 | `.bmp`    | No           | Yes         | No    |
-| `.gif`    | No           | Yes         | No    |
-| `.eps`    | No           | Yes         | No    |
-| `.heic`   | No           | Yes         | No    |
-| `.jpeg`   | No           | Yes         | No    |
-| `.jpg`    | No           | Yes         | No    |
-| `.png`    | No           | Yes         | No    |
-| `.ps`     | No           | Yes         | No    |
-| `.psd`    | No           | Yes         | No    |
-| `.svg`    | No           | Yes         | No    |
-| `.tif`    | No           | Yes         | No    |
-| `.tiff`   | No           | Yes         | No    |
+| `.cr2`    | No           | Yes         | No    |
 | `.dcm`    | No           | Yes         | No    |
 | `.dicm`   | No           | Yes         | No    |
 | `.dicom`  | No           | Yes         | No    |
-| `.svs`    | No           | Yes         | No    |
+| `.dng`    | No           | Yes         | No    |
+| `.eps`    | No           | Yes         | No    |
+| `.exr`    | No           | Yes         | No    |
+| `.gif`    | No           | Yes         | No    |
+| `.heic`   | No           | Yes         | No    |
+| `.indd`   | No           | Yes         | No    |
+| `.indml`  | No           | Yes         | No    |
+| `.indt`   | No           | Yes         | No    |
+| `.inx`    | No           | Yes         | No    |
+| `.jpeg`   | No           | Yes         | No    |
+| `.jpg`    | No           | Yes         | No    |
+| `.nef`    | No           | Yes         | No    |
+| `.png`    | No           | Yes         | No    |
+| `.svg`    | No           | Yes         | No    |
+| `.tif`    | No           | Yes         | No    |
+| `.tiff`   | No           | Yes         | No    |
 | `.tga`    | No           | Yes         | No    |
+| `.svs`    | No           | Yes         | No    |
 
-## Audio Files
+## Presentation
 
-| File Type | PDF Support? | Thumbnails? | Text? |
-| --------- | ------------ | ----------- | ----- |
-| `.aac`    | No           | Yes         | No    |
-| `.aif`    | No           | Yes         | No    |
-| `.aifc`   | No           | Yes         | No    |
-| `.aiff`   | No           | Yes         | No    |
-| `.amr`    | No           | Yes         | No    |
-| `.au`     | No           | Yes         | No    |
-| `.flac`   | No           | Yes         | No    |
-| `.m4a`    | No           | Yes         | No    |
-| `.mp3`    | No           | Yes         | No    |
-| `.ogg`    | No           | Yes         | No    |
-| `.ra`     | No           | Yes         | No    |
-| `.wav`    | No           | Yes         | No    |
-| `.wma`    | No           | Yes         | No    |
+| File Type  | PDF Support? | Thumbnails? | Text? |
+| ---------- | ------------ | ----------- | ----- |
+| `.fodp`    | Yes          | Yes         | Yes   |
+| `.gslide`  | Yes          | Yes         | Yes   |
+| `.gslides` | Yes          | Yes         | Yes   |
+| `.key`     | Yes          | Yes         | Yes   |
+| `.keynote` | Yes          | Yes         | Yes   |
+| `.odp`     | Yes          | Yes         | Yes   |
+| `.otp`     | Yes          | Yes         | Yes   |
+| `.pez`     | Yes          | Yes         | Yes   |
+| `.pot`     | Yes          | Yes         | Yes   |
+| `.ppt`     | Yes          | Yes         | Yes   |
+| `.pptx`    | Yes          | Yes         | Yes   |
 
-## Video Files
+## Spreadsheet
 
-| File Type | PDF Support? | Thumbnails? | Text? |
-| --------- | ------------ | ----------- | ----- |
-| `.3g2`    | No           | Yes         | No    |
-| `.3gp`    | No           | Yes         | No    |
-| `.avi`    | No           | Yes         | No    |
-| `.m2v`    | No           | Yes         | No    |
-| `.m2ts`   | No           | Yes         | No    |
-| `.m4v`    | No           | Yes         | No    |
-| `.mkv`    | No           | Yes         | No    |
-| `.mov`    | No           | Yes         | No    |
-| `.mp4`    | No           | Yes         | No    |
-| `.mpeg`   | No           | Yes         | No    |
-| `.mpg`    | No           | Yes         | No    |
-| `.ogg`    | No           | Yes         | No    |
-| `.mts`    | No           | Yes         | No    |
-| `.qt`     | No           | Yes         | No    |
-| `.ts`     | No           | Yes         | No    |
-| `.wmv`    | No           | Yes         | No    |
+| File Type  | PDF Support? | Thumbnails? | Text? |
+| ---------- | ------------ | ----------- | ----- |
+| `.csv` | Yes | Yes | Yes |
+| `.fods` | Yes | Yes | Yes |
+| `.gsheet` | Yes | Yes | Yes |
+| `.numbers` | Yes | Yes | Yes |
+| `.ods` | Yes | Yes | Yes |
+| `.tsv` | Yes | Yes | Yes |
+| `.xls` | Yes | Yes | Yes |
+| `xlsm` | Yes | Yes | Yes |
+| `xlsx` | Yes | Yes | Yes |
+| `xlsb` | Yes | Yes | Yes |
 
-## Flash/Mobile Video Files
+## Video
 
-| File Type | PDF Support? | Thumbnails? | Text? |
-| --------- | ------------ | ----------- | ----- |
-| `.flv`    | No           | No          | No    |
-| `.swf`    | No           | No          | No    |
-
-## 3D Graphics and Modeling Files
-
-| File Type | PDF Support? | Thumbnails? | Text? |
-| --------- | ------------ | ----------- | ----- |
-| `.3ds`    | No           | No          | No    |
-| `.box3d`  | No           | No          | No    |
-| `.dwg`    | No           | No          | No    |
-| `.obj`    | No           | No          | No    |
-| `.stl`    | No           | No          | No    |
-| `.fbx`    | No           | No          | No    |
-| `.dae`    | No           | No          | No    |
-| `.ply`    | No           | No          | No    |
+| File Type  | PDF Support? | Thumbnails? | Text? |
+| ---------- | ------------ | ----------- | ----- |
+| `.3g2` | No | Yes | No |
+| `.3gp` | No | Yes | No |
+| `.avi` | No | Yes | No |
+| `.fla` | No | Yes | No |
+| `.flv` | No | Yes | No |
+| `m2v` | No | Yes | No |
+| `.m2ts` | No | Yes | No |
+| `.m4v` | No | Yes | No |
+| `.mkv` | No | Yes | No |
+| `.mov` | No | Yes | No |
+| `.mpeg` | No | Yes | No |
+| `.mpg` | No | Yes | No |
+| `.mts` | No | Yes | No |
+| `.swf` | No | Yes | No |
+| `.ogg` | No | Yes | No |
+| `.qt` | No | Yes | No |
+| `.ts` | No | Yes | No |


### PR DESCRIPTION
# Description

Add the following docs:

- https://staging.developer.box.com/guides/box-ai/get-agent-default-config/ describing how to get the configuration. 
- supported models: https://staging.developer.box.com/guides/box-ai/supported-models/ 

Updated docs:

https://staging.developer.box.com/guides/box-ai/ask-questions/
https://staging.developer.box.com/guides/box-ai/generate-text/ 

Fixes #DDOC-1108
