### PR TITLE
DDOC-1029 Add Swift SDK to the list of SDKs and API Ref tabs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -307,3 +307,4 @@ Fallbacks
 deprecations
 oasdiff
 FIPS
+XCode

--- a/content/guides/tooling/sdks/dotnet-gen.md
+++ b/content/guides/tooling/sdks/dotnet-gen.md
@@ -1,0 +1,33 @@
+---
+rank: 1
+related_endpoints: []
+related_guides:
+ - authentication/jwt
+ - authentication/oauth2
+related_pages:
+ - sdks-and-tools
+required_guides: []
+related_resources: []
+alias_paths: []
+---
+
+# Install .NET SDK (Generated)
+
+You can use Box .NET SDK to call Box APIs in a .NET
+project.
+
+The SDK is available for both .NET Framework 4.5 and .NET Core 1.0 or
+above. The installation of the SDK depends on the framework used.
+
+<CTA to="https://github.com/box/box-dotnet-sdk-gen">
+  Learn more about .NET SDK on GitHub
+</CTA>
+
+To install the .NET SDK in the .NET framework, run the following command using
+the [Nuget][nuget] package manager.
+
+```shell
+PM> Install-Package Box.Sdk.Gen
+```
+
+[nuget]: https://www.nuget.org/

--- a/content/guides/tooling/sdks/dotnet.md
+++ b/content/guides/tooling/sdks/dotnet.md
@@ -11,10 +11,18 @@ related_resources: []
 alias_paths: []
 ---
 
-# Install .NET SDK
+# Install .NET SDK (Deprecated)
 
 You can use Box .NET SDK to call Box APIs in a .NET
 project.
+
+<Message type='notice'>
+ [.NET SDK](https://github.com/box/box-windows-sdk-v2)
+ is currently in maintenance mode and will be deprecated soon.
+ This means only critical security updates and bug fixes will be
+ implemented.
+ It is recommended to use the [auto-generated .NET SDK][dotnetgensdk].
+</Message>
 
 The SDK is available for both .NET Framework 4.5 and .NET Core 1.0 or
 above. The installation of the SDK depends on the framework used.
@@ -42,3 +50,4 @@ PM> Install-Package Box.V2.Core
 ```
 
 [nuget]: https://www.nuget.org/
+[dotnetgensdk]: https://github.com/box/box-dotnet-sdk-gen

--- a/content/guides/tooling/sdks/index.md
+++ b/content/guides/tooling/sdks/index.md
@@ -43,7 +43,7 @@ experience and streamline your integration
 with the Box Content Cloud.
 
 <Message type='notice'>
-.NET SDK and Swift SDK are in a Public Beta phase.
+Swift SDK is in a Public Beta phase.
 </Message>
 
 Here's what you can expect from the new SDKs:
@@ -57,7 +57,7 @@ Here's what you can expect from the new SDKs:
 | ------------------------------- | ------------| -------- |
 | [Python Gen SDK][pythongensdk]  |     Yes     |    Full    |
 | [Typescript Gen SDK][tsgensdk]  |     Yes     |    Full    |
-| [.NET SDK][dotnetgensdk] (Beta) |     Yes     |    Full    |
+| [.NET SDK][dotnetgensdk]        |     Yes     |    Full    |
 | [SWift SDK][swiftgensdk] (Beta) |     Yes     |    Full    |
 
 ## SDKs
@@ -68,11 +68,12 @@ when building your applications.
 | Platform   |  Maintained?  | API Parity |
 | --- | ------- |-------- |
 | [Java SDK][javasdk]   | |    Full    |
-| [.NET SDK][dotnetsdk]  | Soon to be deprecated. Only critical security updates and bug fixes are implemented. |    Full    |
-| [Python SDK][pythonsdk]   | Soon to be deprecated. Only critical security updates and bug fixes are implemented. |    Full    |
 | [Node SDK][nodesdk]  |   Yes      |    Full    |
 | [iOS Content SDK][iossdk]   |   Yes    |    Full    |
 | [Android Content SDK][androidsdk] |   No   |  Partial   |
+| [.NET SDK][dotnetsdk]             | Deprecated. Only critical security updates and bug fixes are implemented.            |    Full    |
+| [Python SDK][pythonsdk]           | Deprecated. Only critical security updates and bug fixes are implemented.            |    Full    |
+| [Node SDK][nodesdk]               | Deprecated. Only critical security updates and bug fixes are implemented.            |    Full    |
 
 <Message type='warning'>
 As of May 31, 2023 Android SDK is no

--- a/content/guides/tooling/sdks/index.md
+++ b/content/guides/tooling/sdks/index.md
@@ -38,12 +38,12 @@ these projects to full parity.
 ## Next generation SDKs
 
 The latest generation Box Python SDK, Box Typescript
-SDK and .NET SDK are designed to elevate the developer
+SDK, .NET SDK, and Swift SDK are designed to elevate the developer
 experience and streamline your integration
 with the Box Content Cloud.
 
 <Message type='notice'>
-.NET SDK is in a Public Beta phase.
+.NET SDK and Swift SDK are in a Public Beta phase.
 </Message>
 
 Here's what you can expect from the new SDKs:
@@ -54,10 +54,11 @@ Here's what you can expect from the new SDKs:
 - **Enhanced Convenience Methods**: The newly introduced convenience methods cover various aspects such as authentication, chunk uploads, exponential back-offs, automatic retries, type checkers which help to ensure that you’re using variables correctly, and much more.
 
 | Platform                        | Maintained? | API Parity |
-| ------------------------------- | ---------| -------- |
+| ------------------------------- | ------------| -------- |
 | [Python Gen SDK][pythongensdk]  |     Yes     |    Full    |
 | [Typescript Gen SDK][tsgensdk]  |     Yes     |    Full    |
 | [.NET SDK][dotnetgensdk] (Beta) |     Yes     |    Full    |
+| [SWift SDK][swiftgensdk] (Beta) |     Yes     |    Full    |
 
 ## SDKs
 
@@ -97,6 +98,7 @@ Refer to [this][android-docs] documentation for more details.
 [pythongensdk]: https://github.com/box/box-python-sdk-gen
 [tsgensdk]: https://github.com/box/box-typescript-sdk-gen
 [dotnetgensdk]: https://github.com/box/box-dotnet-sdk-gen
+[swiftsdk]: https://github.com/box/box-swift-sdk-gen
 [android-docs]: https://github.com/box/box-java-sdk/blob/main/doc/android.md
 [forum]: https://support.box.com/hc/en-us/community/topics/360001932973-Platform-and-Developer-Forum
 

--- a/content/guides/tooling/sdks/index.md
+++ b/content/guides/tooling/sdks/index.md
@@ -57,8 +57,8 @@ Here's what you can expect from the new SDKs:
 | ------------------------------- | ------------| -------- |
 | [Python Gen SDK][pythongensdk]  |     Yes     |    Full    |
 | [Typescript Gen SDK][tsgensdk]  |     Yes     |    Full    |
-| [.NET SDK][dotnetgensdk]        |     Yes     |    Full    |
-| [SWift SDK][swiftgensdk] (Beta) |     Yes     |    Full    |
+| [.NET Gen SDK][dotnetgensdk]        |     Yes     |    Full    |
+| [Swift Gen SDK][swiftgensdk] (Beta) |     Yes     |    Full    |
 
 ## SDKs
 
@@ -67,8 +67,7 @@ when building your applications.
 
 | Platform   |  Maintained?  | API Parity |
 | --- | ------- |-------- |
-| [Java SDK][javasdk]   | |    Full    |
-| [Node SDK][nodesdk]  |   Yes      |    Full    |
+| [Java SDK][javasdk]   | Yes |    Full    |
 | [iOS Content SDK][iossdk]   |   Yes    |    Full    |
 | [Android Content SDK][androidsdk] |   No   |  Partial   |
 | [.NET SDK][dotnetsdk]             | Deprecated. Only critical security updates and bug fixes are implemented.            |    Full    |
@@ -99,7 +98,7 @@ Refer to [this][android-docs] documentation for more details.
 [pythongensdk]: https://github.com/box/box-python-sdk-gen
 [tsgensdk]: https://github.com/box/box-typescript-sdk-gen
 [dotnetgensdk]: https://github.com/box/box-dotnet-sdk-gen
-[swiftsdk]: https://github.com/box/box-swift-sdk-gen
+[swiftgensdk]: https://github.com/box/box-swift-sdk-gen
 [android-docs]: https://github.com/box/box-java-sdk/blob/main/doc/android.md
 [forum]: https://support.box.com/hc/en-us/community/topics/360001932973-Platform-and-Developer-Forum
 

--- a/content/guides/tooling/sdks/node.md
+++ b/content/guides/tooling/sdks/node.md
@@ -11,7 +11,7 @@ related_resources: []
 alias_paths: []
 ---
 
-# Install Node SDK
+# Install Node SDK (Deprecated)
 
 You can use Box Node SDK to call Box APIs in a Node
 project.

--- a/content/guides/tooling/sdks/python.md
+++ b/content/guides/tooling/sdks/python.md
@@ -11,7 +11,7 @@ related_resources: []
 alias_paths: []
 ---
 
-# Install Python SDK
+# Install Python SDK (Deprecated)
 
 You can use Box Python SDK to call Box APIs in a Python project.
 

--- a/content/guides/tooling/sdks/swift-gen.md
+++ b/content/guides/tooling/sdks/swift-gen.md
@@ -9,7 +9,7 @@ related_resources: []
 alias_paths: []
 ---
 
-# Install Swift SDK
+# Install Swift SDK (Generated)
 
 You can use Box Swift SDK to call Box APIs in a Swift
 project.
@@ -30,7 +30,7 @@ To add a dependency to your Xcode project:
 
 1. Select **File** > **Add Package Dependency** in your Xcode project.
 2. Click the **plus** icon > **Add Package Collection**.
-2. Enter the following repository url `https://github.com/box/box-swift-sdk-gen.git` and click **Load**.
+2. Enter the following repository URL: `https://github.com/box/box-swift-sdk-gen.git` and click **Load**.
 
 Alternatively you can add a dependency to the dependencies value of your `Package.swift`.
 

--- a/content/guides/tooling/sdks/swift.md
+++ b/content/guides/tooling/sdks/swift.md
@@ -1,0 +1,63 @@
+---
+rank: 1
+related_endpoints: []
+related_guides: []
+related_pages:
+ - sdks-and-tools
+required_guides: []
+related_resources: []
+alias_paths: []
+---
+
+# Install Swift SDK
+
+You can use Box Swift SDK to call Box APIs in a Swift
+project.
+
+<Message type='notice'>
+Swift SDK is in a Public Beta phase.
+</Message>
+
+<CTA to="https://github.com/box/box-swift-sdk-gen">
+  Learn more about Swift SDK on GitHub
+</CTA>
+
+## Swift Package Manager
+
+[Swift Package Manager][spm] is a tool for managing the distribution of Swift code. It is integrated with the Swift build system to automate the process of downloading, compiling, and linking dependencies.
+
+To add a dependency to your Xcode project:
+
+1. Select **File** > **Add Package Dependency** in your Xcode project.
+2. Click the **plus** icon > **Add Package Collection**.
+2. Enter the following repository url `https://github.com/box/box-swift-sdk-gen.git` and click **Load**.
+
+Alternatively you can add a dependency to the dependencies value of your `Package.swift`.
+
+For detailed instructions, please see the official documentation for [Swift Package Manager][spm] and [XCode documentation][xcode].
+
+## Carthage
+
+Carthage is a decentralized dependency manager which builds your dependencies and provides you with binary frameworks.
+
+To add a dependency to `BoxSdkGen`:
+
+1. add the following line to your `Cartfile` :
+
+```bash
+git "https://github.com/box/box-swift-sdk-gen.git"
+```
+
+2. Run:
+
+```bash
+carthage bootstrap --use-xcframeworks
+```
+
+3. Drag the built `xcframework` from **Carthage/Build** into your project.
+
+For more detailed instructions, please see the [official documentation for Carthage][carthage].
+
+[spm]: https://www.swift.org/documentation/package-manager/
+[xcode]: https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app
+[carthage]: https://github.com/Carthage/Carthage#adding-frameworks-to-an-application

--- a/content/microcopy/footer.yml
+++ b/content/microcopy/footer.yml
@@ -77,11 +77,18 @@ categories:
         text: Python SDK (Generated)
         // url: link to the Python SDK (Generated)
         url: https://github.com/box/box-python-sdk-gen
+
       dotnet_sdk:
         // text: Text for link to the .NET SDK
         text: .NET SDK
         // url: link to the .Net SDK
         url: https://github.com/box/box-windows-sdk-v2
+      
+      swift_sdk:
+        // text: Text for link to the Swift SDK (Generated)
+        text: Swift SDK (Generated)
+        // url: link to the Swift SDK (Generated)
+        url: 
 
       dotnet_gen_sdk:
         // text: Text for link to the .NET (Generated) SDK

--- a/content/microcopy/footer.yml
+++ b/content/microcopy/footer.yml
@@ -83,12 +83,12 @@ categories:
         text: .NET SDK
         // url: link to the .Net SDK
         url: https://github.com/box/box-windows-sdk-v2
-      
-      swift_sdk:
+
+      swift_gen_sdk:
         // text: Text for link to the Swift SDK (Generated)
         text: Swift SDK (Generated)
         // url: link to the Swift SDK (Generated)
-        url: 
+        url: https://github.com/box/box-swift-sdk-gen
 
       dotnet_gen_sdk:
         // text: Text for link to the .NET (Generated) SDK

--- a/content/microcopy/reference.yml
+++ b/content/microcopy/reference.yml
@@ -200,7 +200,7 @@ environments:
   // swift_gen: |-
     A label for Swift code sample from
     auto-generated SDK - DO NOT TRANSLATE
-  swift_gen: Swift Gen
+  swift_gen: Swift Gen (Beta)
 
 resource_variants:
   // base: |-

--- a/content/microcopy/reference.yml
+++ b/content/microcopy/reference.yml
@@ -197,6 +197,10 @@ environments:
     A label for .NET code sample from
     auto-generated SDK - DO NOT TRANSLATE
   dotnet_gen: .NET Gen
+  // swift_gen: |-
+    A label for Swift code sample from
+    auto-generated SDK - DO NOT TRANSLATE
+  swift_gen: Swift Gen
 
 resource_variants:
   // base: |-

--- a/content/pages/sdks-and-tools/index.md
+++ b/content/pages/sdks-and-tools/index.md
@@ -42,8 +42,8 @@ these projects to full parity.
 
 ### Next generation SDKs
 
-The latest generation Box Python SDK and Box Typescript
-SDK are designed to elevate the developer
+The latest generation Box Python SDK, Box Typescript
+SDK, .NET SDK, and Swift SDK are designed to elevate the developer
 experience and streamline your integration
 with the Box Content Cloud.
 


### PR DESCRIPTION
# Description

dd Swift SDK to the list of SDKs and API Ref tabs

Staging preview:

https://staging.developer.box.com/sdks-and-tools/
https://staging.developer.box.com/guides/tooling/sdks/ (and subpages)
Footer checked

Fixes # DDOC-1029

