### PR TITLE
Corrected MetadataQueryView code under ContentExplorer

### DIFF
--- a/content/guides/embed/ui-elements/explorer.md
+++ b/content/guides/embed/ui-elements/explorer.md
@@ -352,8 +352,9 @@ function App() {
 
     // Define metadata source
     // Example: enterprise_123456789.metadatatemplate
-    const metadataSource = `metadata.enterprise_${EID}.${templateName}`;
-
+    const metadataSource = `enterprise_${EID}.${templateName}`;
+    const metadataSourceFieldName = `metadata.${metadataSource}`;
+    
     const metadataQuery = {
         from: metadataSource,
 
@@ -368,22 +369,22 @@ function App() {
 
         // Define which other metadata fields you'd like to display
         fields: [
-            `${metadataSource}.name`,
-            `${metadataSource}.last_contacted_at`,
-            `${metadataSource}.industry`,
-            `${metadataSource}.role`,
+            `${metadataSourceFieldName}.name`,
+            `${metadataSourceFieldName}.last_contacted_at`,
+            `${metadataSourceFieldName}.industry`,
+            `${metadataSourceFieldName}.role`,
         ],
     };
 
     // The metadata fields/columns to view - must be valid field names from the metadata template
     const fieldsToShow = [
         // Determine if the user can edit the metadata directly from Content Explorer component
-        { key: `${metadataSource}.name`, canEdit: false },
+        { key: `${metadataSourceFieldName}.name`, canEdit: false },
 
         // Determine label alias on metadata column with displayName prop
-        { key: `${metadataSource}.industry`, canEdit: false, displayName: "alias" },
-        { key: `${metadataSource}.last_contacted_at`, canEdit: true },
-        { key: `${metadataSource}.role`, canEdit: true },
+        { key: `${metadataSourceFieldName}.industry`, canEdit: false, displayName: "alias" },
+        { key: `${metadataSourceFieldName}.last_contacted_at`, canEdit: true },
+        { key: `${metadataSourceFieldName}.role`, canEdit: true },
     ];
 
     // defaultView - a required prop to paint the metadata view.


### PR DESCRIPTION
The word `metadata` should not be in the `from` property
everywhere else for `fields` and `fieldsToShow`, the word `metadata` has to be there