### PR TITLE
Add IBM Llama models

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -341,3 +341,7 @@ strikethrough
 theming
 Agentforce
 DocGen
+agentic
+MoE
+multimodality
+10m

--- a/content/guides/box-ai/ai-models/ibm-llama-3-2-instruct-model-card.md
+++ b/content/guides/box-ai/ai-models/ibm-llama-3-2-instruct-model-card.md
@@ -1,0 +1,36 @@
+---
+rank: 18
+related_guides:
+- box-ai/ai-tutorials/ask-questions
+- box-ai/ai-tutorials/generate-text
+- box-ai/ai-tutorials/extract-metadata
+- box-ai/ai-tutorials/extract-metadata-structured
+- box-ai/ai-agents/get-agent-default-config
+---
+
+# IBM Llama 3.2 Instruct
+
+**IBM Llama 3.2 Instruct** is a instruction-tuned text only model optimized for multilingual dialogue use cases, including agentic retrieval and summarization tasks.
+
+## Model details
+
+| Item | Value | Description |
+|-----------|----------|----------|
+|Model name|**IBM Llama 3.2 Instruct**| The name of the model. |
+|API model name|`ibm__llama_3_2_instruct`| The name of the model that is used in the [Box AI API for model overrides][overrides]. The user must provide this exact name for the API to work. |
+|Hosting layer| **IBM** | The trusted organization that securely hosts LLM. |
+|Model provider|**Meta**| The organization that provides this model. |
+|Release date|**September 25th 2024** | The release date for the model.|
+| Knowledge cutoff date| **December 2023**| The date after which the model does not get any information updates. |
+| Context length | **128k** | The maximum number of tokens that an LLM can process in a single input sequence. |
+| Empirical throughput | N/A | The number of tokens the model can generate per second.|
+| Open source | **Yes** | Specifies if the model's code is available for public use.|
+| IP Infringement Protection | **No** | [Legal note][subprocessors]
+
+## Additional documentation
+
+For additional information, see [official IBM Llama 3.2 Instruct documentation][IBM].
+
+[overrides]: g://box-ai/ai-agents/ai-agent-overrides
+[subprocessors]: https://www.box.com/legal/subprocessors
+[IBM]: https://www.ibm.com/docs/en/watsonx/w-and-w/2.1.0?topic=models-third-party-foundation

--- a/content/guides/box-ai/ai-models/ibm-llama-4-scout-model-card.md
+++ b/content/guides/box-ai/ai-models/ibm-llama-4-scout-model-card.md
@@ -1,0 +1,36 @@
+---
+rank: 18
+related_guides:
+- box-ai/ai-tutorials/ask-questions
+- box-ai/ai-tutorials/generate-text
+- box-ai/ai-tutorials/extract-metadata
+- box-ai/ai-tutorials/extract-metadata-structured
+- box-ai/ai-agents/get-agent-default-config
+---
+
+# IBM Llama 3.2 Instruct
+
+**IBM Llama 3.2 Instruct** is a, auto-regressive language model that uses a mixture-of-experts (MoE) architecture and incorporates early fusion for native multimodality.
+
+## Model details
+
+| Item | Value | Description |
+|-----------|----------|----------|
+|Model name|**IBM Llama 4 Scout**| The name of the model. |
+|API model name|`ibm__llama_4_scout`| The name of the model that is used in the [Box AI API for model overrides][overrides]. The user must provide this exact name for the API to work. |
+|Hosting layer| **IBM** | The trusted organization that securely hosts LLM. |
+|Model provider|**Meta**| The organization that provides this model. |
+|Release date|**April 5th 2025** | The release date for the model.|
+| Knowledge cutoff date| **August 2024**| The date after which the model does not get any information updates. |
+| Context length | **10m** | The maximum number of tokens that an LLM can process in a single input sequence. |
+| Empirical throughput | N/A | The number of tokens the model can generate per second.|
+| Open source | **Yes** | Specifies if the model's code is available for public use.|
+| IP Infringement Protection | **No** | [Legal note][subprocessors]
+
+## Additional documentation
+
+For additional information, see [official IBM Llama 4 Scout documentation][IBM].
+
+[overrides]: g://box-ai/ai-agents/ai-agent-overrides
+[subprocessors]: https://www.box.com/legal/subprocessors
+[IBM]: https://www.ibm.com/docs/en/watsonx/w-and-w/2.1.0?topic=models-third-party-foundation

--- a/content/guides/box-ai/ai-models/index.md
+++ b/content/guides/box-ai/ai-models/index.md
@@ -115,6 +115,18 @@ Models offered in **Preview** mode have not been fully performance-tested at sca
         <strong style="background-color: #fffbf3">Preview</strong>
       </div>
     </Tile>
+		<Tile type="model" title="ibm__llama_3_2_instruct" href="/guides/box-ai/ai-models/ibm-llama-3-2-instruct-model-card">
+      An instruction-tuned text only model optimized for multilingual dialogue use cases, including agentic retrieval and summarization tasks.
+      <div>
+        <strong style="background-color: #e8e8e8">Chat</strong>
+      </div>
+    </Tile>
+		<Tile type="model" title="ibm__llama_4_scout" href="/guides/box-ai/ai-models/ibm-llama-4-scout-model-card">
+      A natively multimodal AI model that enables text and multimodal experiences.
+      <div>
+        <strong style="background-color: #e8e8e8">Chat</strong>
+      </div>
+    </Tile>
 </TileGrid>
 
 [ask]: e://post_ai_ask


### PR DESCRIPTION
# Description

Added IBM Llama 3.2 Instruct and IBM Llama 4 to the [Supported AI models page](https://developer.box.com/guides/box-ai/ai-models/).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch
