### PR TITLE
Add missing link and note

### DIFF
--- a/content/pages/sign/20-technical-use-cases/20-sign-template.md
+++ b/content/pages/sign/20-technical-use-cases/20-sign-template.md
@@ -47,6 +47,15 @@ like so:
 
 ![Adding the signature, name, and date to the template](images/sign-template-signature-props.png)
 
+<Message type='notice'>
+
+You can add an [extra layer of security][additional-sec] for a recipient.
+It works for both a defined recipient with a pre-defined email address, and a
+placeholder recipient, where the template user has to provide their email
+address.
+
+</Message>
+
 Save the template.
 
 ## Identify the template
@@ -617,3 +626,4 @@ signature tags that can be used by the Box Sign engine. Take a look at our
 [template]: https://support.box.com/hc/en-us/sections/21356768117651-Templates
 [request-options]: page://sign/request-options
 [structured-docs]: page://sign/technical-use-cases/sign-structured-docs
+[additional-sec]: page://sign/request-options/extra-security


### PR DESCRIPTION
# Description

Re-add missing link and missing note.
This task was completed in the [PR 711](https://github.com/box/developer.box.com/pull/711), but the note and link disappeared from the docs despite no changes visible in repo.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
