### PR TITLE
Remove "beta" tag from MCP server guide

### DIFF
--- a/content/guides/box-mcp/index.md
+++ b/content/guides/box-mcp/index.md
@@ -23,9 +23,6 @@ Check the detailed guides on both types of Box MCP Servers, as the level of the 
 <TileGrid rows="2">
   <Tile type="mcp" title="Remote Box MCP Server" href="/guides/box-mcp/remote">
     Enable the remote Box MCP Server in the Admin Console. It is hosted directly in Box.
-    <div>
-    <strong style="background-color: #e1ffe7">Beta</strong>
-    </div>
   </Tile>
   <Tile type="mcp" title="Self-hosted Box MCP Server" href="/guides/box-mcp/self-hosted">
     An open source Box Developer community project. You can clone this Box MCP Sever and host it on your local machine.

--- a/content/guides/box-mcp/remote/index.md
+++ b/content/guides/box-mcp/remote/index.md
@@ -9,16 +9,12 @@ required_guides: []
 
 The remote Box MCP Server allows third party AI systems to securely connect and interact with your content in Box.
 
-<Message type='notice'>
-  Box MCP Server offered subject to Box’s Main Beta Agreement, meaning the available capabilities may change at any time. Box MCP Server is available for customers with Enterprise Plus or Enterprise Advanced plans.
-</Message>
-
 ## Access and manage predefined Box MCP Servers
 
 1. Click **Integrations** in the sidebar of Box Admin Console. 
 2. Click **Box Integrations & Clients** in the Integrations window.
 3. Scroll down to **Individual Integration Controls**.
-4. Search for predefined Box MCP Server, for example the **Box MCP Server for Copilot Studio (Beta)**. 
+4. Search for predefined Box MCP Server, for example the **Box MCP Server for Copilot Studio**. 
 5. Hover on the chosen integration, then click **Configure**.
 6. Click Save.
 
@@ -64,7 +60,7 @@ Exact steps may vary depending on the AI platform. Refer to your platform’s do
 
 ### Anthropic's Messages API
 
-Connect the remote Box MCP Server with Anthropic's Messages API (beta). Clone [this sample chat bot project](https://github.com/box-community/remote-box-mcp-anthropic) to get started quickly. It allows you to have a conversation with an Anthropic model, which has access to tools provided by the Box remote MCP server. The chatbot runs in a terminal, maintains conversation history for context-aware responses, and uses `asyncio` for asynchronous operation.
+Connect the remote Box MCP Server with Anthropic's Messages API. Clone [this sample chat bot project](https://github.com/box-community/remote-box-mcp-anthropic) to get started quickly. It allows you to have a conversation with an Anthropic model, which has access to tools provided by the Box remote MCP server. The chatbot runs in a terminal, maintains conversation history for context-aware responses, and uses `asyncio` for asynchronous operation.
 
 ### Copilot Studio
 


### PR DESCRIPTION
# Description

Removed "beta" tag from MCP server guide.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
