### PR TITLE
Fix timeout value for folders

### DIFF
--- a/content/guides/folders/single/delete.md
+++ b/content/guides/folders/single/delete.md
@@ -38,5 +38,5 @@ operation can performed on any of the locked folders.
 
 ## Timeout
 
-Timeout for this operation is 600 seconds. The operation will include
+Timeout for this operation is 600 seconds. The operation will complete
 after a `HTTP 503` has been returned.

--- a/content/guides/folders/single/delete.md
+++ b/content/guides/folders/single/delete.md
@@ -38,5 +38,5 @@ operation can performed on any of the locked folders.
 
 ## Timeout
 
-Timeout for this operation is 60 seconds. The operation will include
+Timeout for this operation is 600 seconds. The operation will include
 after a `HTTP 503` has been returned.

--- a/content/guides/folders/single/update.md
+++ b/content/guides/folders/single/update.md
@@ -28,5 +28,5 @@ also prohibited.
 
 ## Timeout
 
-Timeout for this operation is 60 seconds. The operation will complete
+Timeout for this operation is 600 seconds. The operation will complete
 after a `HTTP 503` has been returned.


### PR DESCRIPTION
# Description

Change the timeout value from 60 sec to 600 sec for Folders API.

Fixes [DDOC-1279](https://jira.inside-box.net/browse/DDOC-1279).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn lint` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
