### PR TITLE
Update triggers.md

### DIFF
--- a/content/guides/webhooks/triggers.md
+++ b/content/guides/webhooks/triggers.md
@@ -30,9 +30,9 @@ available for folders.
 | `COMMENT.CREATED` | A comment object is created. | Yes | Yes |
 | `COMMENT.UPDATED` | A comment object is edited. | Yes | Yes |
 | `COMMENT.DELETED` | A comment object is removed. | Yes | Yes |
-| `DOCGEN_DOCUMENT_GENERATION_FAILED` | Doc Gen failed to generate a document. | Yes | No |
-| `DOCGEN_DOCUMENT_GENERATION_STARTED` | Doc Gen started to create a document. | Yes | No |
-| `DOCGEN_DOCUMENT_GENERATION_SUCCEEDED` | Doc Gen succeeded to create a document. | Yes | No |
+| `DOCGEN_DOCUMENT_GENERATION.FAILED` | Doc Gen failed to generate a document. | Yes | No |
+| `DOCGEN_DOCUMENT_GENERATION.STARTED` | Doc Gen started to create a document. | Yes | No |
+| `DOCGEN_DOCUMENT_GENERATION.SUCCEEDED` | Doc Gen succeeded to create a document. | Yes | No |
 | `FILE.UPLOADED` | A file is uploaded or moved to this folder. | No | Yes |
 | `FILE.PREVIEWED` | A file is previewed. | Yes | Yes |
 | `FILE.DOWNLOADED` | A file is downloaded. | Yes | Yes |


### PR DESCRIPTION
# Description

triggers.md lists incorrect trigger values for docgen triggers. 

> It lists DOCGEN_DOCUMENT_GENERATION_FAILED, DOCGEN_DOCUMENT_GENERATION_STARTED, and DOCGEN_DOCUMENT_GENERATION_SUCCEEDED. 
> 
> Those don't work. DOCGEN_DOCUMENT_GENERATION.FAILED, DOCGEN_DOCUMENT_GENERATION.STARTED, and DOCGEN_DOCUMENT_GENERATION.SUCCEEDED do work. (tested via API)

This branch updates to correct format.

If you are a Boxer, please also reference the related `DDOC` or `APIWG` tickets.
If you do not have a related `Jira` ticket and this is more than a bug fix, then
create one now.

Fixes # (issue)
Re `DDOC-1643`

## Checklist

- [y ] My code follows the style guidelines of this project
- [y ] I have performed a self-review of my own changes
- [ n] I have run `yarn lint` to make sure my changes pass all linters
- [ y] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
